### PR TITLE
Fix framework container and lifecycle semantics

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,13 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      - name: Build wheel
+      - name: Lint
+        run: uv run ruff check
+
+      - name: Test
+        run: uv run pytest
+
+      - name: Build distributions
         run: uv build
 
       - name: Store the distribution packages

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@
 The design inspiration for this framework comes from the [Spring Framework](https://github.com/spring-projects/). 
 I am especially impressed by its powerful automatic assembly feature.
 
+## Quick Start
+`build()` is synchronous and only constructs the application object. `run()` uses the configured event loop, creating one only when needed, and keeps the application alive until it is stopped. If you pass your own loop, it must not already be running.
+
+```python
+from persica.applicationbuilder import ApplicationBuilder
+
+app = ApplicationBuilder().set_scanner_package("example_app").build()
+
+# Blocks until the application is stopped, for example with Ctrl+C.
+app.run()
+```
+
+```python
+# example_app/components.py
+from persica.factory.component import AsyncInitializingComponent
+
+
+class HelloComponent(AsyncInitializingComponent):
+    async def initialize(self):
+        print("Persica is running")
+
+    async def shutdown(self):
+        print("Persica stopped")
+```
+
 ## Future
 - [ ] Support full path scanning
 - [ ] Support custom factory assembly

--- a/persica/application.py
+++ b/persica/application.py
@@ -1,6 +1,7 @@
 import asyncio
 import platform
 import signal
+import threading
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -29,7 +30,8 @@ class Application:
         context_class: type["ApplicationContext"],
         loop: "AbstractEventLoop | None" = None,
     ) -> None:
-        self.loop = loop or asyncio.get_event_loop()
+        self.loop = loop
+        self._owns_loop = False
         self.factory = factory
         self.class_scanner = class_scanner
         self.registry = registry
@@ -39,24 +41,57 @@ class Application:
 
     def run(self) -> None:
         self._logger.info("Application Run")
-        self.context.run()
         self._run()
 
-    def _run(self, stop_signals: Sequence[int] | None = None) -> None:
-        if platform.system() != "Windows":
+    def _run(self, stop_signals: Sequence[int] | None = None) -> None:  # noqa: PLR0912
+        loop = self._get_runtime_loop()
+        if loop.is_running():
+            raise RuntimeError("Application.run() requires a configured event loop that is not already running")
+
+        self.context.run()
+
+        primary_error: Exception | None = None
+        if platform.system() != "Windows" and threading.current_thread() is threading.main_thread():
             stop_signals = (signal.SIGINT, signal.SIGTERM, signal.SIGABRT)
         if stop_signals is not None:
             for sig in stop_signals or []:
-                self.loop.add_signal_handler(sig, self._raise_system_exit)
+                loop.add_signal_handler(sig, self._raise_system_exit)
         try:
-            self.loop.run_until_complete(self.initialize())
-            self.loop.run_forever()
+            loop.run_until_complete(self.initialize())
+            loop.run_forever()
         except (KeyboardInterrupt, SystemExit):
             self._logger.info("Interrupt received! shutting down...")
         except Exception as e:
+            primary_error = e
             self._logger.exception("Exception raised:", exc_info=e)
         finally:
-            self.loop.run_until_complete(self.shutdown())
+            try:
+                loop.run_until_complete(self.shutdown())
+            except Exception as shutdown_error:
+                if primary_error is None:
+                    primary_error = shutdown_error
+                else:
+                    self._logger.exception("Shutdown raised during error handling", exc_info=shutdown_error)
+            finally:
+                if self._owns_loop:
+                    asyncio.set_event_loop(None)
+                    loop.close()
+                    self.loop = None
+                    self._owns_loop = False
+
+        if primary_error is not None:
+            raise primary_error.with_traceback(primary_error.__traceback__)
+
+    def _get_runtime_loop(self) -> "AbstractEventLoop":
+        if self.loop is not None:
+            return self.loop
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._owns_loop = True
+
+        self.loop = loop
+        return loop
 
     @staticmethod
     def _raise_system_exit() -> None:

--- a/persica/context/application.py
+++ b/persica/context/application.py
@@ -1,7 +1,6 @@
 import asyncio
 from collections import defaultdict
-from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from persica.factory.component import AsyncInitializingComponent
 from persica.utils.logging import get_logger
@@ -41,9 +40,9 @@ class ApplicationContext:
         await self._process_components("initialize")
 
     async def shutdown(self) -> None:
-        await self._process_components("shutdown")
+        await self._process_components("shutdown", reverse=True, collect_errors=True)
 
-    async def _process_components(self, method_name: str):
+    async def _process_components(self, method_name: str, *, reverse: bool = False, collect_errors: bool = False):
         components_by_order = defaultdict(list)
 
         for component_dict in [self.factory.singleton_factories, self.factory.singleton_objects]:
@@ -51,14 +50,25 @@ class ApplicationContext:
                 if isinstance(value, AsyncInitializingComponent):
                     method = getattr(value, method_name, None)
                     if method:
-                        components_by_order[value.__order__].append(self._run_async(method))
+                        components_by_order[value.__order__].append(method)
 
-        for order in sorted(components_by_order.keys()):
-            tasks = components_by_order[order]
-            await asyncio.gather(*tasks)
+        errors: list[BaseException] = []
+        for order in sorted(components_by_order.keys(), reverse=reverse):
+            tasks = [asyncio.create_task(method()) for method in components_by_order[order]]
+            try:
+                results = await asyncio.gather(*tasks, return_exceptions=collect_errors)
+            except BaseException:
+                for task in tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                raise
+            if not collect_errors:
+                continue
+            for result in results:
+                if isinstance(result, BaseException):
+                    errors.append(result)
+                    self._logger.exception("Run Error", exc_info=result)
 
-    async def _run_async(self, func: Callable[..., Coroutine[Any, Any, Any]]):
-        try:
-            await func()
-        except Exception as e:
-            self._logger.exception("Run Error", exc_info=e)
+        if errors:
+            raise RuntimeError(f"Application shutdown failed with {len(errors)} error(s)") from errors[-1]

--- a/persica/error.py
+++ b/persica/error.py
@@ -1,2 +1,6 @@
 class NoSuchParameterException(Exception):
     pass
+
+
+class AmbiguousDependencyException(Exception):
+    pass

--- a/persica/factory/abstract.py
+++ b/persica/factory/abstract.py
@@ -2,7 +2,7 @@ import inspect
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, cast
 
-from persica.error import NoSuchParameterException
+from persica.error import AmbiguousDependencyException, NoSuchParameterException
 from persica.factory.definition import ObjectDefinition
 from persica.factory.interface import InterfaceFactory
 from persica.utils.logging import get_logger
@@ -16,22 +16,29 @@ _LOGGER = get_logger(__name__, "AbstractAutowireCapableFactory")
 class AbstractAutowireCapableFactory:
     _logger: "Logger" = _LOGGER
     # 存储对象定义对应的加载顺序的映射表，key 为顺序，value 为 ObjectDefinition
-    order_definitions: dict[int, ObjectDefinition] = {}
+    order_definitions: dict[int, list[ObjectDefinition]]
     # 存储对象定义的映射表，key 为对象的类，value 为 ObjectDefinition
-    object_definitions: dict[type[object], ObjectDefinition] = {}
+    object_definitions: dict[type[object], ObjectDefinition]
     # 工厂缓存，缓存已经创建的工厂对象，key 为对象的类，value 为工厂实例
-    factory_cache: dict[type[object], InterfaceFactory] = {}
+    factory_cache: dict[type[object], InterfaceFactory]
     # 存储已经实例化的单例对象，key 为对象的类，value 为对象实例
-    singleton_objects: dict[type[object], object] = {}
+    singleton_objects: dict[type[object], object]
     # 存储已经实例化的工厂对象，key 为工厂类，value 为工厂实例
-    singleton_factories: dict[type[InterfaceFactory], InterfaceFactory] = {}
+    singleton_factories: dict[type[InterfaceFactory], InterfaceFactory]
     # 存储外部可注入的对象，key 为对象的类，value 为对象实例
-    external_objects: dict[type[object], object] = {}
+    external_objects: dict[type[object], object]
 
     def __init__(self, external_objects: Iterable[object] | None = None):
         """
         初始化工厂，允许外部传入可解析的对象，并将它们存入 external_objects。
         """
+        self.order_definitions = {}
+        self.object_definitions = {}
+        self.factory_cache = {}
+        self.singleton_objects = {}
+        self.singleton_factories = {}
+        self.external_objects = {}
+
         if external_objects is not None:
             for obj in external_objects:
                 original_class = obj.__class__
@@ -46,10 +53,15 @@ class AbstractAutowireCapableFactory:
         实例化 object_definitions 中所有的对象。
         """
         self._logger.info("Instantiating all objects")
+        ordered_classes: set[type[object]] = set()
         sorted_definition = sorted(self.order_definitions.items())
-        for _, value in sorted_definition:
-            self.get_object(value.class_object)
+        for _, definitions in sorted_definition:
+            for definition in definitions:
+                ordered_classes.add(definition.class_object)
+                self.get_object(definition.class_object)
         for definition in self.object_definitions.values():
+            if definition.class_object in ordered_classes:
+                continue
             self.get_object(definition.class_object)
 
     def get_object(self, cls: type[object]):
@@ -79,6 +91,7 @@ class AbstractAutowireCapableFactory:
         创建一个对象实例，支持依赖注入和工厂管理。
         """
         self._logger.info("Creating object %s", cls.__name__)
+        definition = self.object_definitions.get(cls)
         # 查找是否有该类的工厂
         factory = self._find_factory_for_class(cls)
         # 构建构造函数参数
@@ -89,9 +102,12 @@ class AbstractAutowireCapableFactory:
         if factory is not None:
             instance = factory.get_object(obj)
             if instance is not None:
-                self.singleton_objects[cls] = obj
+                self.singleton_objects[cls] = instance
                 return instance
         # 如果没有工厂管理，直接返回对象
+        if definition is not None and definition.is_factory:
+            self.singleton_factories[cast("type[InterfaceFactory]", cls)] = cast("InterfaceFactory", obj)
+            return obj
         self.singleton_objects[cls] = obj
         return obj
 
@@ -99,26 +115,43 @@ class AbstractAutowireCapableFactory:
         """
         查找与给定类对应的工厂，如果没有找到则返回 None。
         """
-        # 先检查工厂缓存中是否存在
         factory = self.factory_cache.get(cls)
-        if factory is None:
-            # 遍历 object_definitions 查找是否有与该类对应的工厂
-            for key, definition in self.object_definitions.items():
-                if definition.is_factory:
-                    factory_cls = cast("type[InterfaceFactory]", key)
-                    # 判断该类是否是工厂管理的类或其子类
-                    if issubclass(cls, factory_cls.get_class()):
-                        factory_instance = self.singleton_factories.get(factory_cls)
-                        if factory_instance is None:
-                            factory_instance = self.create_object(factory_cls)
-                            factory = cast("InterfaceFactory", factory_instance)
-                        else:
-                            factory = factory_instance
-                        # 缓存工厂实例
-                        self.factory_cache[cls] = factory
-                        self.singleton_factories[factory_cls] = factory
-                        break
-        return factory
+        if factory is not None:
+            return factory
+
+        exact_matches: list[type[InterfaceFactory]] = []
+        compatible_matches: list[type[InterfaceFactory]] = []
+        for key, definition in self.object_definitions.items():
+            if not definition.is_factory:
+                continue
+            factory_cls = cast("type[InterfaceFactory]", key)
+            target_class = factory_cls.get_class()
+            if target_class == cls:
+                exact_matches.append(factory_cls)
+                continue
+            if issubclass(cls, target_class):
+                compatible_matches.append(factory_cls)
+
+        selected_factory_cls: type[InterfaceFactory] | None = None
+        if len(exact_matches) == 1:
+            selected_factory_cls = exact_matches[0]
+        elif len(exact_matches) > 1:
+            raise AmbiguousDependencyException(f"Multiple factories exactly match the {cls.__name__} product")
+        elif len(compatible_matches) == 1:
+            selected_factory_cls = compatible_matches[0]
+        elif len(compatible_matches) > 1:
+            raise AmbiguousDependencyException(f"Multiple compatible factories found for the {cls.__name__} product")
+
+        if selected_factory_cls is None:
+            return None
+
+        factory_instance = self.singleton_factories.get(selected_factory_cls)
+        if factory_instance is None:
+            factory_instance = cast("InterfaceFactory", self.create_object(selected_factory_cls))
+
+        self.factory_cache[cls] = factory_instance
+        self.singleton_factories[selected_factory_cls] = factory_instance
+        return factory_instance
 
     def _build_constructor_params(self, cls: type[object]) -> dict[str, Any]:
         """
@@ -133,19 +166,10 @@ class AbstractAutowireCapableFactory:
 
         params: dict[str, Any] = {}
         for name, parameter in signature.parameters.items():
-            # 跳过 'self', 'args', 'kwargs'
             if name in ("self", "args", "kwargs"):
                 continue
             annotation = parameter.annotation
-            # 从单例缓存或外部对象中获取依赖对象实例
-            instance = self.singleton_objects.get(annotation) or self.external_objects.get(annotation)
-            # 如果没有找到依赖对象，尝试创建
-            if instance is None:
-                object_definition = self.object_definitions.get(annotation)
-                if object_definition is not None:
-                    instance = self.create_object(object_definition.class_object)
-                    self.singleton_objects[object_definition.class_object] = instance
-            # 如果依然没有找到，检查参数是否有默认值
+            instance = self._resolve_dependency(annotation, name)
             if instance is None:
                 if parameter.default != inspect.Parameter.empty:
                     instance = parameter.default
@@ -156,3 +180,44 @@ class AbstractAutowireCapableFactory:
                     )
             params[name] = instance
         return params
+
+    def _resolve_dependency(self, annotation: Any, parameter_name: str) -> object | None:  # noqa: PLR0911, PLR0912
+        if not isinstance(annotation, type):
+            return None
+
+        exact_singleton = self.singleton_objects.get(annotation)
+        if exact_singleton is not None:
+            return exact_singleton
+
+        exact_external = self.external_objects.get(annotation)
+        if exact_external is not None:
+            return exact_external
+
+        exact_definition = self.object_definitions.get(annotation)
+        if exact_definition is not None:
+            return self.get_object(exact_definition.class_object)
+
+        compatible_candidates: dict[type[object], tuple[str, object | ObjectDefinition]] = {}
+        for candidate_cls, instance in self.singleton_objects.items():
+            if issubclass(candidate_cls, annotation):
+                compatible_candidates[candidate_cls] = ("singleton", instance)
+        for candidate_cls, instance in self.external_objects.items():
+            if issubclass(candidate_cls, annotation) and candidate_cls not in compatible_candidates:
+                compatible_candidates[candidate_cls] = ("external", instance)
+        for candidate_cls, definition in self.object_definitions.items():
+            if issubclass(candidate_cls, annotation) and candidate_cls not in compatible_candidates:
+                compatible_candidates[candidate_cls] = ("definition", definition)
+
+        if len(compatible_candidates) > 1:
+            raise AmbiguousDependencyException(
+                f"Multiple compatible dependencies found for parameter {parameter_name} of type "
+                f"{annotation.__name__}: {', '.join(candidate_cls.__name__ for candidate_cls in compatible_candidates)}"
+            )
+        if not compatible_candidates:
+            return None
+
+        _, (source, value) = next(iter(compatible_candidates.items()))
+        if source == "definition":
+            definition = cast("ObjectDefinition", value)
+            return self.get_object(definition.class_object)
+        return cast("object", value)

--- a/persica/factory/component.py
+++ b/persica/factory/component.py
@@ -5,8 +5,8 @@ class BaseComponent:
     __order__: int = DEFAULT_ORDER
 
     def __init_subclass__(cls, **kwargs):
+        order = kwargs.pop("order", None)
         super().__init_subclass__(**kwargs)
-        order = kwargs.get("order")
         if order is not None:
             cls.__order__ = order
 

--- a/persica/factory/registry.py
+++ b/persica/factory/registry.py
@@ -1,3 +1,4 @@
+import inspect
 from importlib import import_module
 from typing import TYPE_CHECKING
 
@@ -18,25 +19,25 @@ _LOGGER = get_logger(__name__, "DefinitionRegistry")
 
 class DefinitionRegistry:
     _logger: "Logger" = _LOGGER
-    import_module_status: dict[str, bool] = {}
 
     def __init__(self, factory: "AbstractAutowireCapableFactory", class_scanner: "ClassPathScanner"):
         self.factory = factory
         self.class_scanner = class_scanner
+        self.import_module_status: dict[str, bool] = {}
 
     def flash(self):
+        self.import_module_status = {}
+        self.factory.object_definitions = {}
+        self.factory.order_definitions = {}
+        self.factory.factory_cache = {}
+        self.factory.singleton_objects = {}
+        self.factory.singleton_factories = {}
         self._import_module()
         self._registry_class()
         self._check_class()
 
     def _import_module(self):
-        for module_name in self.class_scanner.get_modules_to_import("persica.factory.component.BaseComponent"):
-            self.__import_module(module_name)
-        for module_name in self.class_scanner.get_modules_to_import(
-            "persica.factory.component.AsyncInitializingComponent"
-        ):
-            self.__import_module(module_name)
-        for module_name in self.class_scanner.get_modules_to_import("persica.factory.interface.InterfaceFactory"):
+        for module_name in self._get_framework_modules():
             self.__import_module(module_name)
 
     def __import_module(self, module_name: str):
@@ -51,20 +52,66 @@ class DefinitionRegistry:
                 raise
 
     def _registry_class(self):
-        self._registry_base_class(BaseComponent)
-        self._registry_base_class(InterfaceFactory, True)
+        for module_name, imported in self.import_module_status.items():
+            if not imported:
+                continue
+            module = import_module(module_name)
+            for _, cls in inspect.getmembers(module, inspect.isclass):
+                if cls.__module__ != module_name:
+                    continue
+                if issubclass(cls, BaseComponent):
+                    self._register_class(cls)
+                elif issubclass(cls, InterfaceFactory):
+                    self._register_class(cls, is_factory=True)
 
-    def _registry_base_class(self, _class: type[object], is_factory: bool | None = None):
-        for _cls in _class.__subclasses__():
-            definition = ObjectDefinition(_cls, is_factory)
-            if hasattr(_cls, "__order__"):
-                __order__: int = _cls.__order__
-                package_name = _cls.__module__
-                class_name = f"{package_name}.{_cls.__name__}"
-                self.class_scanner.class_graph.set_order(class_name, __order__)
-                self.factory.order_definitions.setdefault(__order__, definition)
-            self.factory.object_definitions.setdefault(_cls, definition)
-            self._registry_base_class(_cls)
+    def _register_class(self, cls: type[object], is_factory: bool | None = None):
+        definition = ObjectDefinition(cls, is_factory)
+        if hasattr(cls, "__order__"):
+            __order__: int = cls.__order__
+            class_name = f"{cls.__module__}.{cls.__name__}"
+            self.class_scanner.class_graph.set_order(class_name, __order__)
+            self.factory.order_definitions.setdefault(__order__, []).append(definition)
+        self.factory.object_definitions.setdefault(cls, definition)
+
+    def _get_framework_modules(self) -> set[str]:
+        modules = self.class_scanner.get_modules_to_import("persica.factory.component.BaseComponent")
+        modules.update(self.class_scanner.get_modules_to_import("persica.factory.component.AsyncInitializingComponent"))
+        modules.update(self.class_scanner.get_modules_to_import("persica.factory.interface.InterfaceFactory"))
+        modules.update(self._get_seeded_framework_modules())
+        return modules
+
+    def _get_seeded_framework_modules(self) -> set[str]:
+        modules: set[str] = set()
+        scanned_modules = set(self.class_scanner.scanned_modules)
+        for class_name, module_name in self.class_scanner.class_graph.class_to_module.items():
+            if module_name not in scanned_modules:
+                continue
+            if not self.class_scanner.class_graph.graph.has_node(class_name):
+                continue
+            parent_names = set(self.class_scanner.class_graph.graph.predecessors(class_name))
+            for parent_name in parent_names:
+                if parent_name in self.class_scanner.class_graph.class_to_module:
+                    continue
+                parent_class = self._resolve_runtime_class(parent_name)
+                if parent_class is None:
+                    continue
+                if issubclass(parent_class, BaseComponent) or issubclass(parent_class, InterfaceFactory):
+                    modules.update(self.class_scanner.get_modules_to_import(class_name))
+                    break
+        return modules
+
+    def _resolve_runtime_class(self, class_name: str) -> type[object] | None:
+        module_name, _, attribute_name = class_name.rpartition(".")
+        if not module_name or not attribute_name:
+            return None
+        try:
+            module = import_module(module_name)
+        except Exception:
+            return None
+        candidate = getattr(module, attribute_name, None)
+        if isinstance(candidate, type):
+            return candidate
+        return None
 
     def _check_class(self):
         conflicts = self.class_scanner.class_graph.check_conflict()

--- a/persica/scanner/path.py
+++ b/persica/scanner/path.py
@@ -20,11 +20,14 @@ class ClassPathScanner:
 
     def __init__(self, default_base_packages: list[str] | None = None):
         self.class_graph = ClassGraph()
+        self.scanned_modules: list[str] = []
         if default_base_packages is None:
             default_base_packages = []
         self.default_base_packages = default_base_packages
 
     def flash(self, base_packages: list[str] | None = None):
+        self.class_graph = ClassGraph()
+        self.scanned_modules = []
         if base_packages is None:
             base_packages = []
         base_packages = base_packages or self.default_base_packages
@@ -34,40 +37,51 @@ class ClassPathScanner:
 
     def parse_base_package(self, base_package: str):
         package_spec = find_spec(base_package)
-        if package_spec is None or package_spec.submodule_search_locations is None:
+        if package_spec is None:
             return
 
-        # 使用 walk_packages 遍历包中的所有模块
+        is_package = package_spec.submodule_search_locations is not None
+        if package_spec.origin is not None:
+            self._parse_module(base_package, package_spec.origin, is_package=is_package)
+
+        if not is_package:
+            return
+
         for module_info in walk_packages(package_spec.submodule_search_locations, prefix=base_package + "."):
-            # 获取模块规范
             mod_spec = find_spec(module_info.name)
             if mod_spec is None or mod_spec.origin is None:
                 continue
 
-            # 跳过内置模块和没有源文件的模块
             if mod_spec.origin == "built-in":
                 continue
 
-            self._logger.info("Find module: %s", module_info.name)
+            self._parse_module(
+                module_info.name,
+                mod_spec.origin,
+                is_package=mod_spec.submodule_search_locations is not None,
+            )
 
-            # 读取模块的源代码
-            try:
-                with open(mod_spec.origin, encoding="utf-8") as file:
-                    source = file.read()
-            except (OSError, FileNotFoundError):
-                continue
+    def _parse_module(self, module_name: str, origin: str, is_package: bool):
+        if origin == "built-in":
+            return
 
-            # 解析源代码为 AST
-            try:
-                tree = ast.parse(source, filename=mod_spec.origin)
-            except SyntaxError as exc:
-                # 处理语法错误
-                self._logger.error("ast parse error", exc_info=exc)
-                continue
+        self._logger.info("Find module: %s", module_name)
+        self.scanned_modules.append(module_name)
 
-            # 创建 ClassVisitor 实例 并访问 AST
-            visitor = ClassVisitor(self.class_graph, module_info.name)
-            visitor.visit(tree)
+        try:
+            with open(origin, encoding="utf-8") as file:
+                source = file.read()
+        except (OSError, FileNotFoundError):
+            return
+
+        try:
+            tree = ast.parse(source, filename=origin)
+        except SyntaxError as exc:
+            self._logger.error("ast parse error", exc_info=exc)
+            return
+
+        visitor = ClassVisitor(self.class_graph, module_name, is_package=is_package)
+        visitor.visit(tree)
 
     def get_modules_to_import(self, superclass_name: str) -> set[str]:
         try:

--- a/persica/scanner/visitor.py
+++ b/persica/scanner/visitor.py
@@ -8,32 +8,47 @@ if TYPE_CHECKING:
 
 
 class ClassVisitor(ast.NodeVisitor):
-    def __init__(self, graph: "ClassGraph", module_prefix: str):
+    def __init__(self, graph: "ClassGraph", module_prefix: str, is_package: bool = False):
         self.graph = graph
         self.imports: dict[str, str] = {}  # 映射本地名称到完整的模块路径
         self.module_prefix = module_prefix  # 当前模块的完整路径
+        self.is_package = is_package
 
     def visit_ImportFrom(self, node):
         """
         处理形如 `from module import ClassName` 的导入语句。
         """
-        module = node.module  # 导入的模块，例如 'a.b.c'
+        module = self._resolve_import_from_module(node)
         for alias in node.names:
             if alias.name == "*":
                 # 对于 'from module import *'，可以根据实际需求处理
                 pass
             else:
-                local_name = alias.asname if alias.asname else alias.name
+                local_name = alias.asname or alias.name
                 full_name = f"{module}.{alias.name}"
                 self.imports[local_name] = full_name
         self.generic_visit(node)
+
+    def _resolve_import_from_module(self, node: ast.ImportFrom) -> str:
+        module = node.module or ""
+        if node.level == 0:
+            return module
+
+        package_parts = self.module_prefix.split(".") if self.is_package else self.module_prefix.split(".")[:-1]
+        upward_levels = max(node.level - 1, 0)
+        if upward_levels:
+            package_parts = package_parts[:-upward_levels]
+
+        if module:
+            package_parts.extend(module.split("."))
+        return ".".join(package_parts)
 
     def visit_Import(self, node):
         """
         处理形如 `import module` 或 `import module as mod` 的导入语句。
         """
         for alias in node.names:
-            local_name = alias.asname if alias.asname else alias.name
+            local_name = alias.asname or alias.name
             self.imports[local_name] = alias.name  # 直接存储模块的完整路径
         self.generic_visit(node)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ dependencies = [
     "networkx>=3.3",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "black>=24.8.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=5.0.0",

--- a/sample_namespace_package/child_module.py
+++ b/sample_namespace_package/child_module.py
@@ -1,0 +1,6 @@
+class NamespaceBase:
+    pass
+
+
+class NamespaceChild(NamespaceBase):
+    pass

--- a/tests/context/test_application_lifecycle.py
+++ b/tests/context/test_application_lifecycle.py
@@ -1,0 +1,251 @@
+import asyncio
+import gc
+import threading
+
+import pytest
+
+from persica.applicationbuilder import ApplicationBuilder
+from persica.context.application import ApplicationContext
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.registry import DefinitionRegistry
+from persica.scanner.path import ClassPathScanner
+from tests.lifecycle_failure_package import events as init_failure_events
+from tests.lifecycle_failure_package import reset_events as reset_init_failure_events
+from tests.lifecycle_package import events as lifecycle_events
+from tests.lifecycle_package import reset_events as reset_lifecycle_events
+from tests.lifecycle_rescan_package import events as lifecycle_rescan_events
+from tests.lifecycle_rescan_package import reset_events as reset_lifecycle_rescan_events
+from tests.lifecycle_same_order_failure_package import events as same_order_init_failure_events
+from tests.lifecycle_same_order_failure_package import get_initialize_gate
+from tests.lifecycle_same_order_failure_package import reset_events as reset_same_order_init_failure_events
+from tests.run_failure_package import events as run_failure_events
+from tests.run_failure_package import reset_events as reset_run_failure_events
+from tests.run_lifecycle_package import events as run_lifecycle_events
+from tests.run_lifecycle_package import reset_events as reset_run_lifecycle_events
+from tests.shutdown_failure_package import events as shutdown_failure_events
+from tests.shutdown_failure_package import reset_events as reset_shutdown_failure_events
+
+
+class TestApplicationLifecycle:
+    def test_build_does_not_require_current_event_loop(self):
+        result: dict[str, object] = {}
+
+        def build_application() -> None:
+            try:
+                asyncio.set_event_loop(None)
+                result["app"] = ApplicationBuilder().set_scanner_package("tests.lifecycle_package").build()
+            except Exception as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=build_application)
+        thread.start()
+        thread.join()
+
+        assert "error" not in result
+        assert result["app"] is not None
+
+    @pytest.mark.asyncio
+    async def test_initialize_and_shutdown_follow_component_order(self):
+        reset_lifecycle_events()
+        app = ApplicationBuilder().set_scanner_package("tests.lifecycle_package").build()
+
+        await asyncio.get_running_loop().run_in_executor(None, app.context.run)
+        await app.initialize()
+        await app.shutdown()
+
+        assert lifecycle_events == [
+            "initialize:default",
+            "initialize:early",
+            "initialize:late",
+            "shutdown:late",
+            "shutdown:early",
+            "shutdown:default",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure_is_raised_to_caller(self):
+        reset_init_failure_events()
+        app = ApplicationBuilder().set_scanner_package("tests.lifecycle_failure_package").build()
+
+        await asyncio.get_running_loop().run_in_executor(None, app.context.run)
+
+        with pytest.raises(RuntimeError, match="initialize failed"):
+            await app.initialize()
+
+        assert init_failure_events == ["initialize:success", "initialize:failure"]
+
+    @pytest.mark.asyncio
+    async def test_initialize_failure_cancels_same_order_siblings_before_shutdown(self):
+        reset_same_order_init_failure_events()
+        app = ApplicationBuilder().set_scanner_package("tests.lifecycle_same_order_failure_package").build()
+
+        await asyncio.get_running_loop().run_in_executor(None, app.context.run)
+
+        with pytest.raises(RuntimeError, match="same-order initialize failed"):
+            await app.initialize()
+
+        await app.shutdown()
+        get_initialize_gate().set()
+        await asyncio.sleep(0)
+
+        assert "initialize:blocking:finished" not in same_order_init_failure_events
+        assert "initialize:blocking:cancelled" in same_order_init_failure_events
+        assert same_order_init_failure_events.index(
+            "initialize:blocking:cancelled"
+        ) < same_order_init_failure_events.index("shutdown:blocking")
+
+    @pytest.mark.asyncio
+    async def test_shutdown_attempts_all_components_before_raising(self):
+        reset_shutdown_failure_events()
+        app = ApplicationBuilder().set_scanner_package("tests.shutdown_failure_package").build()
+
+        await asyncio.get_running_loop().run_in_executor(None, app.context.run)
+
+        with pytest.raises(RuntimeError, match=r"Application shutdown failed with 2 error\(s\)") as exc_info:
+            await app.shutdown()
+
+        assert shutdown_failure_events == [
+            "shutdown:last",
+            "shutdown:middle",
+            "shutdown:first",
+        ]
+        assert exc_info.value.__cause__ is not None
+        assert isinstance(exc_info.value.__cause__, asyncio.CancelledError)
+
+    @pytest.mark.asyncio
+    async def test_rescan_replaces_lifecycle_singletons(self):
+        reset_lifecycle_events()
+        reset_lifecycle_rescan_events()
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(["tests.lifecycle_package"])
+        registry = DefinitionRegistry(factory, scanner)
+        context = ApplicationContext(factory=factory, class_scanner=scanner, registry=registry)
+
+        await asyncio.get_running_loop().run_in_executor(None, context.run)
+        await context.initialize()
+        await context.shutdown()
+
+        reset_lifecycle_events()
+        reset_lifecycle_rescan_events()
+        scanner.default_base_packages = ["tests.lifecycle_rescan_package"]
+
+        await asyncio.get_running_loop().run_in_executor(None, context.run)
+        await context.initialize()
+        await context.shutdown()
+
+        assert lifecycle_events == []
+        assert lifecycle_rescan_events == ["initialize:rescan", "shutdown:rescan"]
+
+    def test_run_creates_loop_without_current_event_loop_and_stops_cleanly(self):
+        reset_run_lifecycle_events()
+        result: dict[str, object] = {}
+
+        def run_application() -> None:
+            try:
+                asyncio.set_event_loop(None)
+                app = ApplicationBuilder().set_scanner_package("tests.run_lifecycle_package").build()
+                app.run()
+                result["app"] = app
+            except BaseException as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=run_application)
+        thread.start()
+        thread.join()
+
+        assert "error" not in result
+        assert run_lifecycle_events == ["initialize", "shutdown"]
+
+    def test_run_propagates_initialize_failure(self):
+        reset_run_failure_events()
+        result: dict[str, object] = {}
+
+        def run_application() -> None:
+            try:
+                asyncio.set_event_loop(None)
+                app = ApplicationBuilder().set_scanner_package("tests.run_failure_package").build()
+                app.run()
+            except BaseException as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=run_application)
+        thread.start()
+        thread.join()
+
+        assert isinstance(result.get("error"), RuntimeError)
+        assert str(result["error"]) == "run initialize failed"
+        assert run_failure_events == ["initialize", "shutdown"]
+
+    def test_run_skips_signal_registration_in_non_main_thread_on_non_windows(self, monkeypatch):
+        reset_run_lifecycle_events()
+        result: dict[str, object] = {"signal_calls": 0}
+        original_new_event_loop = asyncio.new_event_loop
+
+        monkeypatch.setattr("persica.application.platform.system", lambda: "Linux")
+
+        def instrumented_new_event_loop():
+            loop = original_new_event_loop()
+
+            def fail_add_signal_handler(*args, **kwargs):
+                result["signal_calls"] = int(result["signal_calls"]) + 1
+                raise AssertionError("signal handlers must not be registered in non-main threads")
+
+            loop.add_signal_handler = fail_add_signal_handler
+            return loop
+
+        monkeypatch.setattr("persica.application.asyncio.new_event_loop", instrumented_new_event_loop)
+
+        def run_application() -> None:
+            try:
+                asyncio.set_event_loop(None)
+                app = ApplicationBuilder().set_scanner_package("tests.run_lifecycle_package").build()
+                app.run()
+            except BaseException as exc:
+                result["error"] = exc
+
+        thread = threading.Thread(target=run_application)
+        thread.start()
+        thread.join()
+
+        assert "error" not in result
+        assert result["signal_calls"] == 0
+        assert run_lifecycle_events == ["initialize", "shutdown"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.filterwarnings(
+        "error:coroutine 'Application\\.(initialize|shutdown)' was never awaited:RuntimeWarning"
+    )
+    @pytest.mark.filterwarnings("error::pytest.PytestUnraisableExceptionWarning")
+    async def test_run_with_running_configured_loop_fails_without_coroutine_warnings(self, recwarn):
+        reset_run_lifecycle_events()
+        app = (
+            ApplicationBuilder()
+            .set_loop(asyncio.get_running_loop())
+            .set_scanner_package("tests.run_lifecycle_package")
+            .build()
+        )
+        calls: list[str] = []
+
+        def fail_class_scanner_flash() -> None:
+            calls.append("class_scanner.flash")
+
+        def fail_registry_flash() -> None:
+            calls.append("registry.flash")
+
+        def fail_factory_instantiate_all_objects() -> None:
+            calls.append("factory.instantiate_all_objects")
+
+        app.class_scanner.flash = fail_class_scanner_flash
+        app.registry.flash = fail_registry_flash
+        app.factory.instantiate_all_objects = fail_factory_instantiate_all_objects
+
+        with pytest.raises(RuntimeError, match="already running"):
+            app.run()
+
+        gc.collect()
+
+        runtime_warnings = [warning for warning in recwarn if issubclass(warning.category, RuntimeWarning)]
+        assert calls == []
+        assert runtime_warnings == []
+        assert run_lifecycle_events == []

--- a/tests/factory/test_factory.py
+++ b/tests/factory/test_factory.py
@@ -32,6 +32,22 @@ class ProductFactory(InterfaceFactory[Product]):
         return obj
 
 
+class ReplacementProductFactory(InterfaceFactory[Product]):
+    def get_object(self, obj: Product | None) -> Product:
+        replacement = Product()
+        replacement.name = "Replacement Product"
+        return replacement
+
+
+class DerivedProductFactory(ProductFactory):
+    pass
+
+
+class NeedsProductFactory:
+    def __init__(self, factory: ProductFactory):
+        self.factory = factory
+
+
 class UnresolvedClass:
     def __init__(self, missing_dependency):
         self.missing_dependency = missing_dependency
@@ -73,12 +89,71 @@ class TestAbstractAutowireCapableFactory:
         assert isinstance(product_instance, Product)
         assert product_instance.name == "Product from Factory"
 
+    def test_factory_definitions_are_singleton_cached(self):
+        factory = AbstractAutowireCapableFactory()
+        factory.object_definitions = {
+            ProductFactory: ObjectDefinition(class_object=ProductFactory, is_factory=True),
+        }
+
+        instance1 = factory.get_object(ProductFactory)
+        instance2 = factory.get_object(ProductFactory)
+
+        assert instance1 is not None
+        assert instance1 is instance2
+        assert factory.singleton_factories.get(ProductFactory) is instance1
+
+    def test_factory_annotation_uses_cached_factory_singleton(self):
+        factory = AbstractAutowireCapableFactory()
+        cached_factory = ProductFactory()
+        factory.object_definitions = {
+            ProductFactory: ObjectDefinition(class_object=ProductFactory, is_factory=True),
+            NeedsProductFactory: ObjectDefinition(class_object=NeedsProductFactory),
+        }
+        factory.singleton_factories[ProductFactory] = cached_factory
+
+        instance = factory.create_object(NeedsProductFactory)
+
+        assert isinstance(instance, NeedsProductFactory)
+        assert instance.factory is cached_factory
+        assert factory.singleton_factories[ProductFactory] is cached_factory
+
+    def test_compatible_factory_annotation_uses_cached_subclass_factory_singleton(self):
+        factory = AbstractAutowireCapableFactory()
+        cached_factory = DerivedProductFactory()
+        factory.object_definitions = {
+            DerivedProductFactory: ObjectDefinition(class_object=DerivedProductFactory, is_factory=True),
+            NeedsProductFactory: ObjectDefinition(class_object=NeedsProductFactory),
+        }
+        factory.singleton_factories[DerivedProductFactory] = cached_factory
+
+        instance = factory.create_object(NeedsProductFactory)
+
+        assert isinstance(instance, NeedsProductFactory)
+        assert instance.factory is cached_factory
+        assert factory.singleton_factories[DerivedProductFactory] is cached_factory
+
+    def test_factory_replacement_instance_is_cached_as_singleton(self):
+        factory = AbstractAutowireCapableFactory()
+        factory.object_definitions = {
+            ReplacementProductFactory: ObjectDefinition(class_object=ReplacementProductFactory, is_factory=True),
+            Product: ObjectDefinition(class_object=Product),
+        }
+
+        created = factory.create_object(Product)
+        cached = factory.singleton_objects.get(Product)
+        fetched = factory.get_object(Product)
+
+        assert created is not None
+        assert cached is created
+        assert fetched is created
+        assert created.name == "Replacement Product"
+
     def test_singleton_behavior(self):
         factory = AbstractAutowireCapableFactory()
-        factory.object_definition = {SimpleClass: ObjectDefinition(class_object=SimpleClass)}
+        factory.object_definitions = {SimpleClass: ObjectDefinition(class_object=SimpleClass)}
         factory.instantiate_all_objects()
         instance1 = factory.singleton_objects.get(SimpleClass)
-        instance2 = factory.singleton_objects.get(SimpleClass)
+        instance2 = factory.get_object(SimpleClass)
         assert instance1 is instance2
 
     def test_missing_dependency(self):

--- a/tests/factory/test_factory_state.py
+++ b/tests/factory/test_factory_state.py
@@ -1,0 +1,156 @@
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.component import BaseComponent
+from persica.factory.definition import ObjectDefinition
+from persica.factory.interface import InterfaceFactory
+from persica.factory.registry import DefinitionRegistry
+from persica.scanner.path import ClassPathScanner
+from tests.sample_registry_root.component_module import RootScannedComponent
+
+REGISTERED_ORDER = 7
+
+
+class FirstOrderedDependency:
+    pass
+
+
+class SecondOrderedDependency:
+    pass
+
+
+class ConsumerOfOrderedDependencies:
+    def __init__(self, first: FirstOrderedDependency, second: SecondOrderedDependency):
+        self.first = first
+        self.second = second
+
+
+class RegisteredOrderedDependencyOne(BaseComponent, order=REGISTERED_ORDER):
+    pass
+
+
+class RegisteredOrderedDependencyTwo(BaseComponent, order=REGISTERED_ORDER):
+    pass
+
+
+class RegisteredOrderedConsumer(BaseComponent):
+    def __init__(self, first: RegisteredOrderedDependencyOne, second: RegisteredOrderedDependencyTwo):
+        self.first = first
+        self.second = second
+
+
+class RegisteredFactoryProduct:
+    pass
+
+
+class RegisteredFactoryBase(InterfaceFactory[RegisteredFactoryProduct]):
+    def get_object(self, obj: RegisteredFactoryProduct | None) -> RegisteredFactoryProduct:
+        return obj if obj is not None else RegisteredFactoryProduct()
+
+
+class RegisteredFactoryChild(RegisteredFactoryBase):
+    pass
+
+
+def test_factory_state_is_instance_scoped():
+    external = FirstOrderedDependency()
+    _first_factory = AbstractAutowireCapableFactory(external_objects=[external])
+    second_factory = AbstractAutowireCapableFactory()
+
+    assert second_factory.object_definitions == {}
+    assert second_factory.singleton_objects == {}
+    assert second_factory.factory_cache == {}
+    assert second_factory.external_objects == {}
+
+
+def test_component_order_keyword_sets_order_attribute():
+    component_order = 3
+
+    class OrderedComponent(BaseComponent, order=component_order):
+        pass
+
+    assert OrderedComponent.__order__ == component_order
+
+
+def test_instantiate_all_objects_handles_multiple_definitions_in_same_order_bucket():
+    factory = AbstractAutowireCapableFactory()
+    first_definition = ObjectDefinition(class_object=FirstOrderedDependency)
+    second_definition = ObjectDefinition(class_object=SecondOrderedDependency)
+    consumer_definition = ObjectDefinition(class_object=ConsumerOfOrderedDependencies)
+    factory.order_definitions = {1: [first_definition, second_definition]}
+    factory.object_definitions = {
+        FirstOrderedDependency: first_definition,
+        SecondOrderedDependency: second_definition,
+        ConsumerOfOrderedDependencies: consumer_definition,
+    }
+
+    factory.instantiate_all_objects()
+
+    assert isinstance(factory.singleton_objects.get(FirstOrderedDependency), FirstOrderedDependency)
+    assert isinstance(factory.singleton_objects.get(SecondOrderedDependency), SecondOrderedDependency)
+    consumer = factory.singleton_objects.get(ConsumerOfOrderedDependencies)
+    assert isinstance(consumer, ConsumerOfOrderedDependencies)
+    assert isinstance(consumer.first, FirstOrderedDependency)
+    assert isinstance(consumer.second, SecondOrderedDependency)
+
+
+def test_registry_registration_supports_ordered_component_instantiation():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=["tests.factory"])
+    scanner.flash()
+    registry = DefinitionRegistry(factory, scanner)
+
+    registry.flash()
+    factory.instantiate_all_objects()
+
+    bucket = factory.order_definitions[REGISTERED_ORDER]
+    assert isinstance(bucket, list)
+    assert {definition.class_object for definition in bucket} == {
+        RegisteredOrderedDependencyOne,
+        RegisteredOrderedDependencyTwo,
+    }
+    consumer = factory.singleton_objects.get(RegisteredOrderedConsumer)
+    assert isinstance(consumer, RegisteredOrderedConsumer)
+    assert isinstance(consumer.first, RegisteredOrderedDependencyOne)
+    assert isinstance(consumer.second, RegisteredOrderedDependencyTwo)
+
+
+def test_definition_registry_import_state_is_instance_scoped():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=[])
+    first_registry = DefinitionRegistry(factory, scanner)
+    second_registry = DefinitionRegistry(factory, scanner)
+
+    first_registry.import_module_status["tests.factory.test_factory"] = True
+
+    assert second_registry.import_module_status == {}
+
+
+def test_definition_registry_preserves_factory_flag_for_nested_factory_subclasses():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=["tests.factory"])
+    scanner.flash()
+    registry = DefinitionRegistry(factory, scanner)
+
+    registry.flash()
+
+    definition = factory.object_definitions.get(RegisteredFactoryChild)
+    assert definition is not None
+    assert definition.is_factory is True
+
+
+def test_registry_flash_replaces_factory_registrations_between_scan_roots():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=[])
+    registry = DefinitionRegistry(factory, scanner)
+
+    scanner.flash(base_packages=["tests.factory"])
+    registry.flash()
+
+    assert RegisteredOrderedDependencyOne in factory.object_definitions
+    assert REGISTERED_ORDER in factory.order_definitions
+
+    scanner.flash(base_packages=["tests.sample_registry_root"])
+    registry.flash()
+
+    assert factory.object_definitions == {RootScannedComponent: factory.object_definitions[RootScannedComponent]}
+    assert REGISTERED_ORDER not in factory.order_definitions
+    assert {definition.class_object for definition in factory.order_definitions[0]} == {RootScannedComponent}

--- a/tests/factory/test_resolution.py
+++ b/tests/factory/test_resolution.py
@@ -1,0 +1,223 @@
+import pytest
+
+from persica.error import AmbiguousDependencyException, NoSuchParameterException
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.definition import ObjectDefinition
+from persica.factory.interface import InterfaceFactory
+
+
+class BaseDependency:
+    pass
+
+
+class SingletonDependency(BaseDependency):
+    pass
+
+
+class ExternalDependency(BaseDependency):
+    pass
+
+
+class RegisteredDependency(BaseDependency):
+    pass
+
+
+class AlternateRegisteredDependency(BaseDependency):
+    pass
+
+
+class NeedsBaseDependency:
+    def __init__(self, dependency: BaseDependency):
+        self.dependency = dependency
+
+
+class NeedsDependencyWithDefault:
+    def __init__(self, dependency: BaseDependency = "fallback"):
+        self.dependency = dependency
+
+
+class ResolutionProduct:
+    def __init__(self):
+        self.name = "original"
+
+
+class ResolutionProductChild(ResolutionProduct):
+    pass
+
+
+class ResolutionProductGrandChild(ResolutionProductChild):
+    pass
+
+
+class CompatibleResolutionFactory(InterfaceFactory[ResolutionProduct]):
+    def get_object(self, obj: ResolutionProduct | None) -> ResolutionProduct:
+        if obj is not None:
+            obj.name = "compatible"
+            return obj
+        created = ResolutionProduct()
+        created.name = "compatible"
+        return created
+
+
+class ExactResolutionFactory(InterfaceFactory[ResolutionProductChild]):
+    def get_object(self, obj: ResolutionProductChild | None) -> ResolutionProductChild:
+        if obj is not None:
+            obj.name = "exact"
+            return obj
+        created = ResolutionProductChild()
+        created.name = "exact"
+        return created
+
+
+class AlternateCompatibleResolutionFactory(InterfaceFactory[ResolutionProductChild]):
+    def get_object(self, obj: ResolutionProductChild | None) -> ResolutionProductChild:
+        if obj is not None:
+            obj.name = "alternate-compatible"
+            return obj
+        created = ResolutionProductChild()
+        created.name = "alternate-compatible"
+        return created
+
+
+class ReplacementResolutionFactory(InterfaceFactory[ResolutionProduct]):
+    def get_object(self, obj: ResolutionProduct | None) -> ResolutionProduct:
+        replacement = ResolutionProduct()
+        replacement.name = "replacement"
+        return replacement
+
+
+class NeedsCompatibleFactory:
+    def __init__(self, factory: CompatibleResolutionFactory):
+        self.factory = factory
+
+
+def test_unique_compatible_singleton_dependency_is_injected():
+    factory = AbstractAutowireCapableFactory()
+    singleton = SingletonDependency()
+    factory.singleton_objects[SingletonDependency] = singleton
+
+    resolved = factory._build_constructor_params(NeedsBaseDependency)
+
+    assert resolved["dependency"] is singleton
+
+
+def test_unique_compatible_external_dependency_is_injected():
+    external = ExternalDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+
+    resolved = factory._build_constructor_params(NeedsBaseDependency)
+
+    assert resolved["dependency"] is external
+
+
+def test_unique_compatible_registered_definition_is_created_and_injected():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        RegisteredDependency: ObjectDefinition(class_object=RegisteredDependency),
+    }
+
+    resolved = factory._build_constructor_params(NeedsBaseDependency)
+
+    assert isinstance(resolved["dependency"], RegisteredDependency)
+    assert factory.singleton_objects[RegisteredDependency] is resolved["dependency"]
+
+
+def test_ambiguous_compatible_dependencies_raise_exception():
+    factory = AbstractAutowireCapableFactory()
+    factory.singleton_objects[SingletonDependency] = SingletonDependency()
+    factory.external_objects[ExternalDependency] = ExternalDependency()
+
+    with pytest.raises(AmbiguousDependencyException) as exc_info:
+        factory._build_constructor_params(NeedsBaseDependency)
+
+    assert "dependency" in str(exc_info.value)
+    assert BaseDependency.__name__ in str(exc_info.value)
+
+
+def test_default_parameter_value_is_used_when_dependency_is_missing():
+    factory = AbstractAutowireCapableFactory()
+
+    resolved = factory._build_constructor_params(NeedsDependencyWithDefault)
+
+    assert resolved["dependency"] == "fallback"
+
+
+def test_missing_dependency_without_default_still_raises():
+    factory = AbstractAutowireCapableFactory()
+
+    with pytest.raises(NoSuchParameterException):
+        factory._build_constructor_params(NeedsBaseDependency)
+
+
+def test_exact_factory_target_match_is_preferred_over_compatible_match():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactResolutionFactory: ObjectDefinition(class_object=ExactResolutionFactory, is_factory=True),
+        CompatibleResolutionFactory: ObjectDefinition(class_object=CompatibleResolutionFactory, is_factory=True),
+        ResolutionProductChild: ObjectDefinition(class_object=ResolutionProductChild),
+    }
+
+    created = factory.create_object(ResolutionProductChild)
+
+    assert created.name == "exact"
+    assert factory.singleton_objects[ResolutionProductChild] is created
+
+
+def test_direct_factory_definitions_are_singleton_cached():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactResolutionFactory: ObjectDefinition(class_object=ExactResolutionFactory, is_factory=True),
+    }
+
+    first = factory.get_object(ExactResolutionFactory)
+    second = factory.get_object(ExactResolutionFactory)
+
+    assert first is second
+    assert factory.singleton_factories[ExactResolutionFactory] is first
+
+
+def test_replacement_instance_from_factory_is_cached_as_singleton():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ReplacementResolutionFactory: ObjectDefinition(class_object=ReplacementResolutionFactory, is_factory=True),
+        ResolutionProduct: ObjectDefinition(class_object=ResolutionProduct),
+    }
+
+    created = factory.create_object(ResolutionProduct)
+    fetched = factory.get_object(ResolutionProduct)
+
+    assert created is fetched
+    assert created.name == "replacement"
+    assert factory.singleton_objects[ResolutionProduct] is created
+
+
+def test_compatible_factory_annotation_uses_cached_factory_singleton():
+    factory = AbstractAutowireCapableFactory()
+    cached_factory = CompatibleResolutionFactory()
+    factory.object_definitions = {
+        CompatibleResolutionFactory: ObjectDefinition(class_object=CompatibleResolutionFactory, is_factory=True),
+        NeedsCompatibleFactory: ObjectDefinition(class_object=NeedsCompatibleFactory),
+    }
+    factory.singleton_factories[CompatibleResolutionFactory] = cached_factory
+
+    created = factory.create_object(NeedsCompatibleFactory)
+
+    assert isinstance(created, NeedsCompatibleFactory)
+    assert created.factory is cached_factory
+
+
+def test_ambiguous_compatible_factories_raise_exception():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        CompatibleResolutionFactory: ObjectDefinition(class_object=CompatibleResolutionFactory, is_factory=True),
+        AlternateCompatibleResolutionFactory: ObjectDefinition(
+            class_object=AlternateCompatibleResolutionFactory,
+            is_factory=True,
+        ),
+        ResolutionProductGrandChild: ObjectDefinition(class_object=ResolutionProductGrandChild),
+    }
+
+    with pytest.raises(AmbiguousDependencyException) as exc_info:
+        factory.create_object(ResolutionProductGrandChild)
+
+    assert ResolutionProductGrandChild.__name__ in str(exc_info.value)

--- a/tests/lifecycle_failure_package/__init__.py
+++ b/tests/lifecycle_failure_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/lifecycle_failure_package/components.py
+++ b/tests/lifecycle_failure_package/components.py
@@ -1,0 +1,13 @@
+from persica.factory.component import AsyncInitializingComponent
+from tests.lifecycle_failure_package import events
+
+
+class SuccessfulComponent(AsyncInitializingComponent, order=10):
+    async def initialize(self):
+        events.append("initialize:success")
+
+
+class FailingComponent(AsyncInitializingComponent, order=20):
+    async def initialize(self):
+        events.append("initialize:failure")
+        raise RuntimeError("initialize failed")

--- a/tests/lifecycle_package/__init__.py
+++ b/tests/lifecycle_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/lifecycle_package/components.py
+++ b/tests/lifecycle_package/components.py
@@ -1,0 +1,26 @@
+from persica.factory.component import AsyncInitializingComponent
+from tests.lifecycle_package import events
+
+
+class LateComponent(AsyncInitializingComponent, order=20):
+    async def initialize(self):
+        events.append("initialize:late")
+
+    async def shutdown(self):
+        events.append("shutdown:late")
+
+
+class EarlyComponent(AsyncInitializingComponent, order=10):
+    async def initialize(self):
+        events.append("initialize:early")
+
+    async def shutdown(self):
+        events.append("shutdown:early")
+
+
+class DefaultOrderComponent(AsyncInitializingComponent):
+    async def initialize(self):
+        events.append("initialize:default")
+
+    async def shutdown(self):
+        events.append("shutdown:default")

--- a/tests/lifecycle_rescan_package/__init__.py
+++ b/tests/lifecycle_rescan_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/lifecycle_rescan_package/components.py
+++ b/tests/lifecycle_rescan_package/components.py
@@ -1,0 +1,10 @@
+from persica.factory.component import AsyncInitializingComponent
+from tests.lifecycle_rescan_package import events
+
+
+class RescanLifecycleComponent(AsyncInitializingComponent):
+    async def initialize(self):
+        events.append("initialize:rescan")
+
+    async def shutdown(self):
+        events.append("shutdown:rescan")

--- a/tests/lifecycle_same_order_failure_package/__init__.py
+++ b/tests/lifecycle_same_order_failure_package/__init__.py
@@ -1,0 +1,17 @@
+import asyncio
+
+events: list[str] = []
+_state: dict[str, asyncio.Event | None] = {"initialize_gate": None}
+
+
+def reset_events() -> None:
+    events.clear()
+    _state["initialize_gate"] = asyncio.Event()
+
+
+def get_initialize_gate() -> asyncio.Event:
+    gate = _state["initialize_gate"]
+    if gate is None:
+        gate = asyncio.Event()
+        _state["initialize_gate"] = gate
+    return gate

--- a/tests/lifecycle_same_order_failure_package/components.py
+++ b/tests/lifecycle_same_order_failure_package/components.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from persica.factory.component import AsyncInitializingComponent
+from tests.lifecycle_same_order_failure_package import events, get_initialize_gate
+
+
+class BlockingComponent(AsyncInitializingComponent, order=10):
+    async def initialize(self):
+        events.append("initialize:blocking:start")
+        try:
+            await get_initialize_gate().wait()
+            events.append("initialize:blocking:finished")
+        except asyncio.CancelledError:
+            events.append("initialize:blocking:cancelled")
+            raise
+
+    async def shutdown(self):
+        events.append("shutdown:blocking")
+
+
+class TriggeringFailureComponent(AsyncInitializingComponent, order=10):
+    async def initialize(self):
+        events.append("initialize:failing")
+        raise RuntimeError("same-order initialize failed")
+
+    async def shutdown(self):
+        events.append("shutdown:trigger")

--- a/tests/outside_components.py
+++ b/tests/outside_components.py
@@ -1,0 +1,9 @@
+from persica.factory.component import BaseComponent
+
+
+class OutsideLoadedComponent(BaseComponent):
+    pass
+
+
+class ExternalBaseComponent(BaseComponent):
+    pass

--- a/tests/run_failure_package/__init__.py
+++ b/tests/run_failure_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/run_failure_package/components.py
+++ b/tests/run_failure_package/components.py
@@ -1,0 +1,11 @@
+from persica.factory.component import AsyncInitializingComponent
+from tests.run_failure_package import events
+
+
+class RunFailureComponent(AsyncInitializingComponent):
+    async def initialize(self):
+        events.append("initialize")
+        raise RuntimeError("run initialize failed")
+
+    async def shutdown(self):
+        events.append("shutdown")

--- a/tests/run_lifecycle_package/__init__.py
+++ b/tests/run_lifecycle_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/run_lifecycle_package/components.py
+++ b/tests/run_lifecycle_package/components.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from persica.application import Application
+from persica.factory.component import AsyncInitializingComponent
+from tests.run_lifecycle_package import events
+
+
+class RunLifecycleComponent(AsyncInitializingComponent):
+    def __init__(self, application: Application):
+        self.application = application
+
+    async def initialize(self):
+        events.append("initialize")
+        self.application.loop.create_task(self._stop_application())
+
+    async def shutdown(self):
+        events.append("shutdown")
+
+    async def _stop_application(self):
+        await asyncio.sleep(0)
+        self.application.loop.stop()

--- a/tests/sample_cross_boundary_chain/__init__.py
+++ b/tests/sample_cross_boundary_chain/__init__.py
@@ -1,0 +1,4 @@
+from .module_a import CrossBoundaryRootComponent
+from .module_b import CrossBoundaryLeafComponent
+
+__all__ = ["CrossBoundaryRootComponent", "CrossBoundaryLeafComponent"]

--- a/tests/sample_cross_boundary_chain/module_a.py
+++ b/tests/sample_cross_boundary_chain/module_a.py
@@ -1,0 +1,5 @@
+from tests.outside_components import ExternalBaseComponent
+
+
+class CrossBoundaryRootComponent(ExternalBaseComponent):
+    pass

--- a/tests/sample_cross_boundary_chain/module_b.py
+++ b/tests/sample_cross_boundary_chain/module_b.py
@@ -1,0 +1,5 @@
+from tests.sample_cross_boundary_chain.module_a import CrossBoundaryRootComponent
+
+
+class CrossBoundaryLeafComponent(CrossBoundaryRootComponent):
+    pass

--- a/tests/sample_cross_boundary_module.py
+++ b/tests/sample_cross_boundary_module.py
@@ -1,0 +1,5 @@
+from tests.outside_components import ExternalBaseComponent
+
+
+class LocalCrossBoundaryComponent(ExternalBaseComponent):
+    pass

--- a/tests/sample_module.py
+++ b/tests/sample_module.py
@@ -1,0 +1,28 @@
+from persica.factory.component import BaseComponent
+from persica.factory.interface import InterfaceFactory
+from tests.outside_components import ExternalBaseComponent
+
+
+class DirectModuleBase:
+    pass
+
+
+class DirectModuleChild(DirectModuleBase):
+    pass
+
+
+class ScannedModuleComponent(BaseComponent):
+    pass
+
+
+class ScannedModuleProduct:
+    pass
+
+
+class ScannedModuleFactory(InterfaceFactory[ScannedModuleProduct]):
+    def get_object(self, obj: ScannedModuleProduct | None) -> ScannedModuleProduct:
+        return obj if obj is not None else ScannedModuleProduct()
+
+
+class LocalInheritedComponent(ExternalBaseComponent):
+    pass

--- a/tests/sample_non_framework_boundary/__init__.py
+++ b/tests/sample_non_framework_boundary/__init__.py
@@ -1,0 +1,3 @@
+from .safe_component import SafeBoundaryComponent
+
+__all__ = ["SafeBoundaryComponent"]

--- a/tests/sample_non_framework_boundary/broken_non_framework.py
+++ b/tests/sample_non_framework_boundary/broken_non_framework.py
@@ -1,0 +1,5 @@
+class BrokenNonFrameworkBoundary(Exception):
+    pass
+
+
+raise RuntimeError("non-framework external base module should not be imported")

--- a/tests/sample_non_framework_boundary/safe_component.py
+++ b/tests/sample_non_framework_boundary/safe_component.py
@@ -1,0 +1,5 @@
+from persica.factory.component import BaseComponent
+
+
+class SafeBoundaryComponent(BaseComponent):
+    pass

--- a/tests/sample_package_init/__init__.py
+++ b/tests/sample_package_init/__init__.py
@@ -1,0 +1,6 @@
+class PackageRootBase:
+    pass
+
+
+class PackageRootChild(PackageRootBase):
+    pass

--- a/tests/sample_registry_root/__init__.py
+++ b/tests/sample_registry_root/__init__.py
@@ -1,0 +1,3 @@
+from .component_module import RootScannedComponent
+
+__all__ = ["RootScannedComponent"]

--- a/tests/sample_registry_root/broken_module.py
+++ b/tests/sample_registry_root/broken_module.py
@@ -1,0 +1,1 @@
+raise RuntimeError("this module should not be imported during registry population")

--- a/tests/sample_registry_root/component_module.py
+++ b/tests/sample_registry_root/component_module.py
@@ -1,0 +1,5 @@
+from persica.factory.component import BaseComponent
+
+
+class RootScannedComponent(BaseComponent):
+    pass

--- a/tests/sample_relative_package/__init__.py
+++ b/tests/sample_relative_package/__init__.py
@@ -1,0 +1,4 @@
+from .base import RelativeBase
+from .child import RelativeChild
+
+__all__ = ["RelativeBase", "RelativeChild"]

--- a/tests/sample_relative_package/base.py
+++ b/tests/sample_relative_package/base.py
@@ -1,0 +1,2 @@
+class RelativeBase:
+    pass

--- a/tests/sample_relative_package/child.py
+++ b/tests/sample_relative_package/child.py
@@ -1,0 +1,5 @@
+from .base import RelativeBase
+
+
+class RelativeChild(RelativeBase):
+    pass

--- a/tests/scanner/test_registry_boundary.py
+++ b/tests/scanner/test_registry_boundary.py
@@ -1,0 +1,94 @@
+from importlib import import_module
+
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.registry import DefinitionRegistry
+from persica.scanner.path import ClassPathScanner
+
+
+class TestRegistryBoundary:
+    def test_registry_registers_only_classes_from_scanned_modules(self):
+        outside_module = import_module("tests.outside_components")
+        scanned_module = import_module("tests.sample_module")
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_module"])
+        scanner.flash()
+        registry = DefinitionRegistry(factory, scanner)
+
+        registry.flash()
+
+        assert outside_module.OutsideLoadedComponent not in factory.object_definitions
+        assert scanned_module.ScannedModuleComponent in factory.object_definitions
+        assert scanned_module.ScannedModuleFactory in factory.object_definitions
+        assert factory.object_definitions[scanned_module.ScannedModuleFactory].is_factory is True
+
+    def test_registry_skips_unrelated_broken_modules_under_scan_root(self):
+        scanned_module = import_module("tests.sample_registry_root.component_module")
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_registry_root"])
+        scanner.flash()
+        registry = DefinitionRegistry(factory, scanner)
+
+        registry.flash()
+
+        assert scanned_module.RootScannedComponent in factory.object_definitions
+        assert registry.import_module_status["tests.sample_registry_root.component_module"] is True
+        assert "tests.sample_registry_root.broken_module" not in registry.import_module_status
+
+    def test_registry_registers_scanned_subclass_through_external_base(self):
+        scanned_module = import_module("tests.sample_cross_boundary_module")
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_cross_boundary_module"])
+        scanner.flash()
+        registry = DefinitionRegistry(factory, scanner)
+
+        registry.flash()
+
+        assert scanned_module.LocalCrossBoundaryComponent in factory.object_definitions
+        assert registry.import_module_status["tests.sample_cross_boundary_module"] is True
+
+    def test_registry_skips_modules_with_non_framework_external_bases(self):
+        scanned_module = import_module("tests.sample_non_framework_boundary.safe_component")
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_non_framework_boundary"])
+        scanner.flash()
+        registry = DefinitionRegistry(factory, scanner)
+
+        registry.flash()
+
+        assert scanned_module.SafeBoundaryComponent in factory.object_definitions
+        assert "tests.sample_non_framework_boundary.broken_non_framework" not in registry.import_module_status
+
+    def test_registry_imports_scanned_descendants_of_external_framework_seed(self):
+        root_module = import_module("tests.sample_cross_boundary_chain.module_a")
+        leaf_module = import_module("tests.sample_cross_boundary_chain.module_b")
+
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_cross_boundary_chain"])
+        scanner.flash()
+        registry = DefinitionRegistry(factory, scanner)
+
+        registry.flash()
+
+        assert root_module.CrossBoundaryRootComponent in factory.object_definitions
+        assert leaf_module.CrossBoundaryLeafComponent in factory.object_definitions
+        assert registry.import_module_status["tests.sample_cross_boundary_chain.module_a"] is True
+        assert registry.import_module_status["tests.sample_cross_boundary_chain.module_b"] is True
+
+    def test_registry_flash_resets_import_state_between_scan_roots(self):
+        factory = AbstractAutowireCapableFactory()
+        scanner = ClassPathScanner(default_base_packages=[])
+        registry = DefinitionRegistry(factory, scanner)
+
+        scanner.flash(base_packages=["tests.sample_module"])
+        registry.flash()
+
+        assert registry.import_module_status == {"tests.sample_module": True}
+
+        scanner.flash(base_packages=["tests.sample_registry_root"])
+        registry.flash()
+
+        assert registry.import_module_status == {"tests.sample_registry_root.component_module": True}

--- a/tests/scanner/test_scan_roots.py
+++ b/tests/scanner/test_scan_roots.py
@@ -1,0 +1,50 @@
+from persica.scanner.path import ClassPathScanner
+
+
+class TestScannerRoots:
+    def test_flash_scans_package_root_init_module(self):
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_package_init"])
+
+        scanner.flash()
+
+        graph = scanner.class_graph
+        assert "tests.sample_package_init" in scanner.scanned_modules
+        assert "tests.sample_package_init.PackageRootBase" in graph.graph.nodes
+        assert (
+            "tests.sample_package_init.PackageRootBase",
+            "tests.sample_package_init.PackageRootChild",
+        ) in graph.graph.edges
+
+    def test_flash_scans_direct_module_target(self):
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_module"])
+
+        scanner.flash()
+
+        graph = scanner.class_graph
+        assert scanner.scanned_modules == ["tests.sample_module"]
+        assert "tests.sample_module.DirectModuleBase" in graph.graph.nodes
+        assert ("tests.sample_module.DirectModuleBase", "tests.sample_module.DirectModuleChild") in graph.graph.edges
+
+    def test_flash_resolves_relative_import_edges(self):
+        scanner = ClassPathScanner(default_base_packages=["tests.sample_relative_package"])
+
+        scanner.flash()
+
+        assert "tests.sample_relative_package.base" in scanner.scanned_modules
+        assert "tests.sample_relative_package.child" in scanner.scanned_modules
+        assert (
+            "tests.sample_relative_package.base.RelativeBase",
+            "tests.sample_relative_package.child.RelativeChild",
+        ) in scanner.class_graph.graph.edges
+
+    def test_flash_scans_namespace_package_root(self):
+        scanner = ClassPathScanner(default_base_packages=["sample_namespace_package"])
+
+        scanner.flash()
+
+        assert "sample_namespace_package.child_module" in scanner.scanned_modules
+        assert "sample_namespace_package.child_module.NamespaceBase" in scanner.class_graph.graph.nodes
+        assert (
+            "sample_namespace_package.child_module.NamespaceBase",
+            "sample_namespace_package.child_module.NamespaceChild",
+        ) in scanner.class_graph.graph.edges

--- a/tests/shutdown_failure_package/__init__.py
+++ b/tests/shutdown_failure_package/__init__.py
@@ -1,0 +1,5 @@
+events: list[str] = []
+
+
+def reset_events() -> None:
+    events.clear()

--- a/tests/shutdown_failure_package/components.py
+++ b/tests/shutdown_failure_package/components.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from persica.factory.component import AsyncInitializingComponent
+from tests.shutdown_failure_package import events
+
+
+class LastShutdownComponent(AsyncInitializingComponent, order=30):
+    async def shutdown(self):
+        events.append("shutdown:last")
+        raise RuntimeError("last shutdown failed")
+
+
+class MiddleShutdownComponent(AsyncInitializingComponent, order=20):
+    async def shutdown(self):
+        events.append("shutdown:middle")
+
+
+class FirstShutdownComponent(AsyncInitializingComponent, order=10):
+    async def shutdown(self):
+        events.append("shutdown:first")
+        raise asyncio.CancelledError("first shutdown cancelled")

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,501 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "black"
+version = "26.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c5/61175d618685d42b005847464b8fb4743a67b1b8fdb75e50e5a96c31a27a/black-26.3.1.tar.gz", hash = "sha256:2c50f5063a9641c7eed7795014ba37b0f5fa227f3d408b968936e24bc0566b07", size = 666155, upload-time = "2026-03-12T03:36:03.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/a8/11170031095655d36ebc6664fe0897866f6023892396900eec0e8fdc4299/black-26.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:86a8b5035fce64f5dcd1b794cf8ec4d31fe458cf6ce3986a30deb434df82a1d2", size = 1866562, upload-time = "2026-03-12T03:39:58.639Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ce/9e7548d719c3248c6c2abfd555d11169457cbd584d98d179111338423790/black-26.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5602bdb96d52d2d0672f24f6ffe5218795736dd34807fd0fd55ccd6bf206168b", size = 1703623, upload-time = "2026-03-12T03:40:00.347Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0a/8d17d1a9c06f88d3d030d0b1d4373c1551146e252afe4547ed601c0e697f/black-26.3.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c54a4a82e291a1fee5137371ab488866b7c86a3305af4026bdd4dc78642e1ac", size = 1768388, upload-time = "2026-03-12T03:40:01.765Z" },
+    { url = "https://files.pythonhosted.org/packages/52/79/c1ee726e221c863cde5164f925bacf183dfdf0397d4e3f94889439b947b4/black-26.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:6e131579c243c98f35bce64a7e08e87fb2d610544754675d4a0e73a070a5aa3a", size = 1412969, upload-time = "2026-03-12T03:40:03.252Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a5/15c01d613f5756f68ed8f6d4ec0a1e24b82b18889fa71affd3d1f7fad058/black-26.3.1-cp310-cp310-win_arm64.whl", hash = "sha256:5ed0ca58586c8d9a487352a96b15272b7fa55d139fc8496b519e78023a8dab0a", size = 1220345, upload-time = "2026-03-12T03:40:04.892Z" },
+    { url = "https://files.pythonhosted.org/packages/17/57/5f11c92861f9c92eb9dddf515530bc2d06db843e44bdcf1c83c1427824bc/black-26.3.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:28ef38aee69e4b12fda8dba75e21f9b4f979b490c8ac0baa7cb505369ac9e1ff", size = 1851987, upload-time = "2026-03-12T03:40:06.248Z" },
+    { url = "https://files.pythonhosted.org/packages/54/aa/340a1463660bf6831f9e39646bf774086dbd8ca7fc3cded9d59bbdf4ad0a/black-26.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bf9bf162ed91a26f1adba8efda0b573bc6924ec1408a52cc6f82cb73ec2b142c", size = 1689499, upload-time = "2026-03-12T03:40:07.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/01/b726c93d717d72733da031d2de10b92c9fa4c8d0c67e8a8a372076579279/black-26.3.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:474c27574d6d7037c1bc875a81d9be0a9a4f9ee95e62800dab3cfaadbf75acd5", size = 1754369, upload-time = "2026-03-12T03:40:09.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/09/61e91881ca291f150cfc9eb7ba19473c2e59df28859a11a88248b5cbbc4d/black-26.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:5e9d0d86df21f2e1677cc4bd090cd0e446278bcbbe49bf3659c308c3e402843e", size = 1413613, upload-time = "2026-03-12T03:40:10.943Z" },
+    { url = "https://files.pythonhosted.org/packages/16/73/544f23891b22e7efe4d8f812371ab85b57f6a01b2fc45e3ba2e52ba985b8/black-26.3.1-cp311-cp311-win_arm64.whl", hash = "sha256:9a5e9f45e5d5e1c5b5c29b3bd4265dcc90e8b92cf4534520896ed77f791f4da5", size = 1219719, upload-time = "2026-03-12T03:40:12.597Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/f8/da5eae4fc75e78e6dceb60624e1b9662ab00d6b452996046dfa9b8a6025b/black-26.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e6f89631eb88a7302d416594a32faeee9fb8fb848290da9d0a5f2903519fc1", size = 1895920, upload-time = "2026-03-12T03:40:13.921Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9f/04e6f26534da2e1629b2b48255c264cabf5eedc5141d04516d9d68a24111/black-26.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cd2012d35b47d589cb8a16faf8a32ef7a336f56356babd9fcf70939ad1897f", size = 1718499, upload-time = "2026-03-12T03:40:15.239Z" },
+    { url = "https://files.pythonhosted.org/packages/04/91/a5935b2a63e31b331060c4a9fdb5a6c725840858c599032a6f3aac94055f/black-26.3.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f76ff19ec5297dd8e66eb64deda23631e642c9393ab592826fd4bdc97a4bce7", size = 1794994, upload-time = "2026-03-12T03:40:17.124Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/0a/86e462cdd311a3c2a8ece708d22aba17d0b2a0d5348ca34b40cdcbea512e/black-26.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:ddb113db38838eb9f043623ba274cfaf7d51d5b0c22ecb30afe58b1bb8322983", size = 1420867, upload-time = "2026-03-12T03:40:18.83Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e5/22515a19cb7eaee3440325a6b0d95d2c0e88dd180cb011b12ae488e031d1/black-26.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:dfdd51fc3e64ea4f35873d1b3fb25326773d55d2329ff8449139ebaad7357efb", size = 1230124, upload-time = "2026-03-12T03:40:20.425Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/77/5728052a3c0450c53d9bb3945c4c46b91baa62b2cafab6801411b6271e45/black-26.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:855822d90f884905362f602880ed8b5df1b7e3ee7d0db2502d4388a954cc8c54", size = 1895034, upload-time = "2026-03-12T03:40:21.813Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/7cae55fdfdfbe9d19e9a8d25d145018965fe2079fa908101c3733b0c55a0/black-26.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8a33d657f3276328ce00e4d37fe70361e1ec7614da5d7b6e78de5426cb56332f", size = 1718503, upload-time = "2026-03-12T03:40:23.666Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/87/af89ad449e8254fdbc74654e6467e3c9381b61472cc532ee350d28cfdafb/black-26.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1cd08e99d2f9317292a311dfe578fd2a24b15dbce97792f9c4d752275c1fa56", size = 1793557, upload-time = "2026-03-12T03:40:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/43/10/d6c06a791d8124b843bf325ab4ac7d2f5b98731dff84d6064eafd687ded1/black-26.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:c7e72339f841b5a237ff14f7d3880ddd0fc7f98a1199e8c4327f9a4f478c1839", size = 1422766, upload-time = "2026-03-12T03:40:27.14Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4f/40a582c015f2d841ac24fed6390bd68f0fc896069ff3a886317959c9daf8/black-26.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:afc622538b430aa4c8c853f7f63bc582b3b8030fd8c80b70fb5fa5b834e575c2", size = 1232140, upload-time = "2026-03-12T03:40:28.882Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/e36e27c9cebc1311b7579210df6f1c86e50f2d7143ae4fcf8a5017dc8809/black-26.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2d6bfaf7fd0993b420bed691f20f9492d53ce9a2bcccea4b797d34e947318a78", size = 1889234, upload-time = "2026-03-12T03:40:30.964Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/7b/9871acf393f64a5fa33668c19350ca87177b181f44bb3d0c33b2d534f22c/black-26.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f89f2ab047c76a9c03f78d0d66ca519e389519902fa27e7a91117ef7611c0568", size = 1720522, upload-time = "2026-03-12T03:40:32.346Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/e766c7f2e90c07fb7586cc787c9ae6462b1eedab390191f2b7fc7f6170a9/black-26.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b07fc0dab849d24a80a29cfab8d8a19187d1c4685d8a5e6385a5ce323c1f015f", size = 1787824, upload-time = "2026-03-12T03:40:33.636Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/2424338fb2d1875e9e83eed4c8e9c67f6905ec25afd826a911aea2b02535/black-26.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:0126ae5b7c09957da2bdbd91a9ba1207453feada9e9fe51992848658c6c8e01c", size = 1445855, upload-time = "2026-03-12T03:40:35.442Z" },
+    { url = "https://files.pythonhosted.org/packages/86/43/0c3338bd928afb8ee7471f1a4eec3bdbe2245ccb4a646092a222e8669840/black-26.3.1-cp314-cp314-win_arm64.whl", hash = "sha256:92c0ec1f2cc149551a2b7b47efc32c866406b6891b0ee4625e95967c8f4acfb1", size = 1258109, upload-time = "2026-03-12T03:40:36.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/52d98722666d6fc6c3dd4c76df339501d6efd40e0ff95e6186a7b7f0befd/black-26.3.1-py3-none-any.whl", hash = "sha256:2bd5aa94fc267d38bb21a70d7410a89f1a1d318841855f698746f8e7f51acd1b", size = 207542, upload-time = "2026-03-12T03:36:01.668Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/75/31212c6bf2503fdf920d87fee5d7a86a2e3bcf444984126f13d8e4016804/click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5", size = 302856, upload-time = "2026-04-03T19:14:45.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/20/71885d8b97d4f3dde17b1fdb92dbd4908b00541c5a3379787137285f602e/click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d", size = 108379, upload-time = "2026-04-03T19:14:43.505Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/33/e8c48488c29a73fd089f9d71f9653c1be7478f2ad6b5bc870db11a55d23d/coverage-7.13.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e0723d2c96324561b9aa76fb982406e11d93cdb388a7a7da2b16e04719cf7ca5", size = 219255, upload-time = "2026-03-17T10:29:51.081Z" },
+    { url = "https://files.pythonhosted.org/packages/da/bd/b0ebe9f677d7f4b74a3e115eec7ddd4bcf892074963a00d91e8b164a6386/coverage-7.13.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:52f444e86475992506b32d4e5ca55c24fc88d73bcbda0e9745095b28ef4dc0cf", size = 219772, upload-time = "2026-03-17T10:29:52.867Z" },
+    { url = "https://files.pythonhosted.org/packages/48/cc/5cb9502f4e01972f54eedd48218bb203fe81e294be606a2bc93970208013/coverage-7.13.5-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:704de6328e3d612a8f6c07000a878ff38181ec3263d5a11da1db294fa6a9bdf8", size = 246532, upload-time = "2026-03-17T10:29:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/d8/3217636d86c7e7b12e126e4f30ef1581047da73140614523af7495ed5f2d/coverage-7.13.5-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a1a6d79a14e1ec1832cabc833898636ad5f3754a678ef8bb4908515208bf84f4", size = 248333, upload-time = "2026-03-17T10:29:56.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/30/2002ac6729ba2d4357438e2ed3c447ad8562866c8c63fc16f6dfc33afe56/coverage-7.13.5-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79060214983769c7ba3f0cee10b54c97609dca4d478fa1aa32b914480fd5738d", size = 250211, upload-time = "2026-03-17T10:29:57.938Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/85/552496626d6b9359eb0e2f86f920037c9cbfba09b24d914c6e1528155f7d/coverage-7.13.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:356e76b46783a98c2a2fe81ec79df4883a1e62895ea952968fb253c114e7f930", size = 252125, upload-time = "2026-03-17T10:29:59.388Z" },
+    { url = "https://files.pythonhosted.org/packages/44/21/40256eabdcbccdb6acf6b381b3016a154399a75fe39d406f790ae84d1f3c/coverage-7.13.5-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0cef0cdec915d11254a7f549c1170afecce708d30610c6abdded1f74e581666d", size = 247219, upload-time = "2026-03-17T10:30:01.199Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e8/96e2a6c3f21a0ea77d7830b254a1542d0328acc8d7bdf6a284ba7e529f77/coverage-7.13.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dc022073d063b25a402454e5712ef9e007113e3a676b96c5f29b2bda29352f40", size = 248248, upload-time = "2026-03-17T10:30:03.317Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ba/8477f549e554827da390ec659f3c38e4b6d95470f4daafc2d8ff94eaa9c2/coverage-7.13.5-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:9b74db26dfea4f4e50d48a4602207cd1e78be33182bc9cbf22da94f332f99878", size = 246254, upload-time = "2026-03-17T10:30:04.832Z" },
+    { url = "https://files.pythonhosted.org/packages/55/59/bc22aef0e6aa179d5b1b001e8b3654785e9adf27ef24c93dc4228ebd5d68/coverage-7.13.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:ad146744ca4fd09b50c482650e3c1b1f4dfa1d4792e0a04a369c7f23336f0400", size = 250067, upload-time = "2026-03-17T10:30:06.535Z" },
+    { url = "https://files.pythonhosted.org/packages/de/1b/c6a023a160806a5137dca53468fd97530d6acad24a22003b1578a9c2e429/coverage-7.13.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:c555b48be1853fe3997c11c4bd521cdd9a9612352de01fa4508f16ec341e6fe0", size = 246521, upload-time = "2026-03-17T10:30:08.486Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/3f/3532c85a55aa2f899fa17c186f831cfa1aa434d88ff792a709636f64130e/coverage-7.13.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7034b5c56a58ae5e85f23949d52c14aca2cfc6848a31764995b7de88f13a1ea0", size = 247126, upload-time = "2026-03-17T10:30:09.966Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2e/b9d56af4a24ef45dfbcda88e06870cb7d57b2b0bfa3a888d79b4c8debd76/coverage-7.13.5-cp310-cp310-win32.whl", hash = "sha256:eb7fdf1ef130660e7415e0253a01a7d5a88c9c4d158bcf75cbbd922fd65a5b58", size = 221860, upload-time = "2026-03-17T10:30:11.393Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cc/d938417e7a4d7f0433ad4edee8bb2acdc60dc7ac5af19e2a07a048ecbee3/coverage-7.13.5-cp310-cp310-win_amd64.whl", hash = "sha256:3e1bb5f6c78feeb1be3475789b14a0f0a5b47d505bfc7267126ccbd50289999e", size = 222788, upload-time = "2026-03-17T10:30:12.886Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/37/d24c8f8220ff07b839b2c043ea4903a33b0f455abe673ae3c03bbdb7f212/coverage-7.13.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:66a80c616f80181f4d643b0f9e709d97bcea413ecd9631e1dedc7401c8e6695d", size = 219381, upload-time = "2026-03-17T10:30:14.68Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8b/cd129b0ca4afe886a6ce9d183c44d8301acbd4ef248622e7c49a23145605/coverage-7.13.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:145ede53ccbafb297c1c9287f788d1bc3efd6c900da23bf6931b09eafc931587", size = 219880, upload-time = "2026-03-17T10:30:16.231Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2f/e0e5b237bffdb5d6c530ce87cc1d413a5b7d7dfd60fb067ad6d254c35c76/coverage-7.13.5-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0672854dc733c342fa3e957e0605256d2bf5934feeac328da9e0b5449634a642", size = 250303, upload-time = "2026-03-17T10:30:17.748Z" },
+    { url = "https://files.pythonhosted.org/packages/92/be/b1afb692be85b947f3401375851484496134c5554e67e822c35f28bf2fbc/coverage-7.13.5-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:ec10e2a42b41c923c2209b846126c6582db5e43a33157e9870ba9fb70dc7854b", size = 252218, upload-time = "2026-03-17T10:30:19.804Z" },
+    { url = "https://files.pythonhosted.org/packages/da/69/2f47bb6fa1b8d1e3e5d0c4be8ccb4313c63d742476a619418f85740d597b/coverage-7.13.5-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be3d4bbad9d4b037791794ddeedd7d64a56f5933a2c1373e18e9e568b9141686", size = 254326, upload-time = "2026-03-17T10:30:21.321Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d0/79db81da58965bd29dabc8f4ad2a2af70611a57cba9d1ec006f072f30a54/coverage-7.13.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d2afbc5cc54d286bfb54541aa50b64cdb07a718227168c87b9e2fb8f25e1743", size = 256267, upload-time = "2026-03-17T10:30:23.094Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/32/d0d7cc8168f91ddab44c0ce4806b969df5f5fdfdbb568eaca2dbc2a04936/coverage-7.13.5-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3ad050321264c49c2fa67bb599100456fc51d004b82534f379d16445da40fb75", size = 250430, upload-time = "2026-03-17T10:30:25.311Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/06/a055311d891ddbe231cd69fdd20ea4be6e3603ffebddf8704b8ca8e10a3c/coverage-7.13.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7300c8a6d13335b29bb76d7651c66af6bd8658517c43499f110ddc6717bfc209", size = 252017, upload-time = "2026-03-17T10:30:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f6/d0fd2d21e29a657b5f77a2fe7082e1568158340dceb941954f776dce1b7b/coverage-7.13.5-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:eb07647a5738b89baab047f14edd18ded523de60f3b30e75c2acc826f79c839a", size = 250080, upload-time = "2026-03-17T10:30:29.481Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ab/0d7fb2efc2e9a5eb7ddcc6e722f834a69b454b7e6e5888c3a8567ecffb31/coverage-7.13.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9adb6688e3b53adffefd4a52d72cbd8b02602bfb8f74dcd862337182fd4d1a4e", size = 253843, upload-time = "2026-03-17T10:30:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/6f/7467b917bbf5408610178f62a49c0ed4377bb16c1657f689cc61470da8ce/coverage-7.13.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7c8d4bc913dd70b93488d6c496c77f3aff5ea99a07e36a18f865bca55adef8bd", size = 249802, upload-time = "2026-03-17T10:30:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2c/1172fb689df92135f5bfbbd69fc83017a76d24ea2e2f3a1154007e2fb9f8/coverage-7.13.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0e3c426ffc4cd952f54ee9ffbdd10345709ecc78a3ecfd796a57236bfad0b9b8", size = 250707, upload-time = "2026-03-17T10:30:35.2Z" },
+    { url = "https://files.pythonhosted.org/packages/67/21/9ac389377380a07884e3b48ba7a620fcd9dbfaf1d40565facdc6b36ec9ef/coverage-7.13.5-cp311-cp311-win32.whl", hash = "sha256:259b69bb83ad9894c4b25be2528139eecba9a82646ebdda2d9db1ba28424a6bf", size = 221880, upload-time = "2026-03-17T10:30:36.775Z" },
+    { url = "https://files.pythonhosted.org/packages/af/7f/4cd8a92531253f9d7c1bbecd9fa1b472907fb54446ca768c59b531248dc5/coverage-7.13.5-cp311-cp311-win_amd64.whl", hash = "sha256:258354455f4e86e3e9d0d17571d522e13b4e1e19bf0f8596bcf9476d61e7d8a9", size = 222816, upload-time = "2026-03-17T10:30:38.891Z" },
+    { url = "https://files.pythonhosted.org/packages/12/a6/1d3f6155fb0010ca68eba7fe48ca6c9da7385058b77a95848710ecf189b1/coverage-7.13.5-cp311-cp311-win_arm64.whl", hash = "sha256:bff95879c33ec8da99fc9b6fe345ddb5be6414b41d6d1ad1c8f188d26f36e028", size = 221483, upload-time = "2026-03-17T10:30:40.463Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8c/74fedc9663dcf168b0a059d4ea756ecae4da77a489048f94b5f512a8d0b3/coverage-7.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5ec4af212df513e399cf11610cc27063f1586419e814755ab362e50a85ea69c1", size = 219576, upload-time = "2026-03-17T10:31:09.045Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c9/44fb661c55062f0818a6ffd2685c67aa30816200d5f2817543717d4b92eb/coverage-7.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:941617e518602e2d64942c88ec8499f7fbd49d3f6c4327d3a71d43a1973032f3", size = 219942, upload-time = "2026-03-17T10:31:10.708Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/13/93419671cee82b780bab7ea96b67c8ef448f5f295f36bf5031154ec9a790/coverage-7.13.5-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:da305e9937617ee95c2e39d8ff9f040e0487cbf1ac174f777ed5eddd7a7c1f26", size = 250935, upload-time = "2026-03-17T10:31:12.392Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/68/1666e3a4462f8202d836920114fa7a5ee9275d1fa45366d336c551a162dd/coverage-7.13.5-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:78e696e1cc714e57e8b25760b33a8b1026b7048d270140d25dafe1b0a1ee05a3", size = 253541, upload-time = "2026-03-17T10:31:14.247Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/5e/3ee3b835647be646dcf3c65a7c6c18f87c27326a858f72ab22c12730773d/coverage-7.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:02ca0eed225b2ff301c474aeeeae27d26e2537942aa0f87491d3e147e784a82b", size = 254780, upload-time = "2026-03-17T10:31:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/cb5bd1a04cfcc49ede6cd8409d80bee17661167686741e041abc7ee1b9a9/coverage-7.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:04690832cbea4e4663d9149e05dba142546ca05cb1848816760e7f58285c970a", size = 256912, upload-time = "2026-03-17T10:31:17.89Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/c1dceb7b9714473800b075f5c8a84f4588f887a90eb8645282031676e242/coverage-7.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0590e44dd2745c696a778f7bab6aa95256de2cbc8b8cff4f7db8ff09813d6969", size = 251165, upload-time = "2026-03-17T10:31:19.605Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/62/5502b73b97aa2e53ea22a39cf8649ff44827bef76d90bf638777daa27a9d/coverage-7.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d7cfad2d6d81dd298ab6b89fe72c3b7b05ec7544bdda3b707ddaecff8d25c161", size = 252908, upload-time = "2026-03-17T10:31:21.312Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/37/7792c2d69854397ca77a55c4646e5897c467928b0e27f2d235d83b5d08c6/coverage-7.13.5-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e092b9499de38ae0fbfbc603a74660eb6ff3e869e507b50d85a13b6db9863e15", size = 250873, upload-time = "2026-03-17T10:31:23.565Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/23/bc866fb6163be52a8a9e5d708ba0d3b1283c12158cefca0a8bbb6e247a43/coverage-7.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:48c39bc4a04d983a54a705a6389512883d4a3b9862991b3617d547940e9f52b1", size = 255030, upload-time = "2026-03-17T10:31:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8b/ef67e1c222ef49860701d346b8bbb70881bef283bd5f6cbba68a39a086c7/coverage-7.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:2d3807015f138ffea1ed9afeeb8624fd781703f2858b62a8dd8da5a0994c57b6", size = 250694, upload-time = "2026-03-17T10:31:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/46/0d/866d1f74f0acddbb906db212e096dee77a8e2158ca5e6bb44729f9d93298/coverage-7.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee2aa19e03161671ec964004fb74b2257805d9710bf14a5c704558b9d8dbaf17", size = 252469, upload-time = "2026-03-17T10:31:29.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/f5/be742fec31118f02ce42b21c6af187ad6a344fed546b56ca60caacc6a9a0/coverage-7.13.5-cp313-cp313-win32.whl", hash = "sha256:ce1998c0483007608c8382f4ff50164bfc5bd07a2246dd272aa4043b75e61e85", size = 222112, upload-time = "2026-03-17T10:31:31.526Z" },
+    { url = "https://files.pythonhosted.org/packages/66/40/7732d648ab9d069a46e686043241f01206348e2bbf128daea85be4d6414b/coverage-7.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:631efb83f01569670a5e866ceb80fe483e7c159fac6f167e6571522636104a0b", size = 222923, upload-time = "2026-03-17T10:31:33.633Z" },
+    { url = "https://files.pythonhosted.org/packages/48/af/fea819c12a095781f6ccd504890aaddaf88b8fab263c4940e82c7b770124/coverage-7.13.5-cp313-cp313-win_arm64.whl", hash = "sha256:f4cd16206ad171cbc2470dbea9103cf9a7607d5fe8c242fdf1edf36174020664", size = 221540, upload-time = "2026-03-17T10:31:35.445Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/17879af479df7fbbd44bd528a31692a48f6b25055d16482fdf5cdb633805/coverage-7.13.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0428cbef5783ad91fe240f673cc1f76b25e74bbfe1a13115e4aa30d3f538162d", size = 220262, upload-time = "2026-03-17T10:31:37.184Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4c/d20e554f988c8f91d6a02c5118f9abbbf73a8768a3048cb4962230d5743f/coverage-7.13.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e0b216a19534b2427cc201a26c25da4a48633f29a487c61258643e89d28200c0", size = 220617, upload-time = "2026-03-17T10:31:39.245Z" },
+    { url = "https://files.pythonhosted.org/packages/29/9c/f9f5277b95184f764b24e7231e166dfdb5780a46d408a2ac665969416d61/coverage-7.13.5-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:972a9cd27894afe4bc2b1480107054e062df08e671df7c2f18c205e805ccd806", size = 261912, upload-time = "2026-03-17T10:31:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f6/7f1ab39393eeb50cfe4747ae8ef0e4fc564b989225aa1152e13a180d74f8/coverage-7.13.5-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4b59148601efcd2bac8c4dbf1f0ad6391693ccf7a74b8205781751637076aee3", size = 263987, upload-time = "2026-03-17T10:31:43.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d7/62c084fb489ed9c6fbdf57e006752e7c516ea46fd690e5ed8b8617c7d52e/coverage-7.13.5-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:505d7083c8b0c87a8fa8c07370c285847c1f77739b22e299ad75a6af6c32c5c9", size = 266416, upload-time = "2026-03-17T10:31:45.769Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f6/df63d8660e1a0bff6125947afda112a0502736f470d62ca68b288ea762d8/coverage-7.13.5-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:60365289c3741e4db327e7baff2a4aaacf22f788e80fa4683393891b70a89fbd", size = 267558, upload-time = "2026-03-17T10:31:48.293Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/353ca81d36779bd108f6d384425f7139ac3c58c750dcfaafe5d0bee6436b/coverage-7.13.5-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1b88c69c8ef5d4b6fe7dea66d6636056a0f6a7527c440e890cf9259011f5e606", size = 261163, upload-time = "2026-03-17T10:31:50.125Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/16/2e79106d5749bcaf3aee6d309123548e3276517cd7851faa8da213bc61bf/coverage-7.13.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5b13955d31d1633cf9376908089b7cebe7d15ddad7aeaabcbe969a595a97e95e", size = 263981, upload-time = "2026-03-17T10:31:51.961Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c7/c29e0c59ffa6942030ae6f50b88ae49988e7e8da06de7ecdbf49c6d4feae/coverage-7.13.5-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f70c9ab2595c56f81a89620e22899eea8b212a4041bd728ac6f4a28bf5d3ddd0", size = 261604, upload-time = "2026-03-17T10:31:53.872Z" },
+    { url = "https://files.pythonhosted.org/packages/40/48/097cdc3db342f34006a308ab41c3a7c11c3f0d84750d340f45d88a782e00/coverage-7.13.5-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:084b84a8c63e8d6fc7e3931b316a9bcafca1458d753c539db82d31ed20091a87", size = 265321, upload-time = "2026-03-17T10:31:55.997Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1f/4994af354689e14fd03a75f8ec85a9a68d94e0188bbdab3fc1516b55e512/coverage-7.13.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ad14385487393e386e2ea988b09d62dd42c397662ac2dabc3832d71253eee479", size = 260502, upload-time = "2026-03-17T10:31:58.308Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c6/9bb9ef55903e628033560885f5c31aa227e46878118b63ab15dc7ba87797/coverage-7.13.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7f2c47b36fe7709a6e83bfadf4eefb90bd25fbe4014d715224c4316f808e59a2", size = 262688, upload-time = "2026-03-17T10:32:00.141Z" },
+    { url = "https://files.pythonhosted.org/packages/14/4f/f5df9007e50b15e53e01edea486814783a7f019893733d9e4d6caad75557/coverage-7.13.5-cp313-cp313t-win32.whl", hash = "sha256:67e9bc5449801fad0e5dff329499fb090ba4c5800b86805c80617b4e29809b2a", size = 222788, upload-time = "2026-03-17T10:32:02.246Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/98/aa7fccaa97d0f3192bec013c4e6fd6d294a6ed44b640e6bb61f479e00ed5/coverage-7.13.5-cp313-cp313t-win_amd64.whl", hash = "sha256:da86cdcf10d2519e10cabb8ac2de03da1bcb6e4853790b7fbd48523332e3a819", size = 223851, upload-time = "2026-03-17T10:32:04.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8b/e5c469f7352651e5f013198e9e21f97510b23de957dd06a84071683b4b60/coverage-7.13.5-cp313-cp313t-win_arm64.whl", hash = "sha256:0ecf12ecb326fe2c339d93fc131816f3a7367d223db37817208905c89bded911", size = 222104, upload-time = "2026-03-17T10:32:06.65Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/77/39703f0d1d4b478bfd30191d3c14f53caf596fac00efb3f8f6ee23646439/coverage-7.13.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fbabfaceaeb587e16f7008f7795cd80d20ec548dc7f94fbb0d4ec2e038ce563f", size = 219621, upload-time = "2026-03-17T10:32:08.589Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3e/51dff36d99ae14639a133d9b164d63e628532e2974d8b1edb99dd1ebc733/coverage-7.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9bb2a28101a443669a423b665939381084412b81c3f8c0fcfbac57f4e30b5b8e", size = 219953, upload-time = "2026-03-17T10:32:10.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6c/1f1917b01eb647c2f2adc9962bd66c79eb978951cab61bdc1acab3290c07/coverage-7.13.5-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:bd3a2fbc1c6cccb3c5106140d87cc6a8715110373ef42b63cf5aea29df8c217a", size = 250992, upload-time = "2026-03-17T10:32:12.41Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e5/06b1f88f42a5a99df42ce61208bdec3bddb3d261412874280a19796fc09c/coverage-7.13.5-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6c36ddb64ed9d7e496028d1d00dfec3e428e0aabf4006583bb1839958d280510", size = 253503, upload-time = "2026-03-17T10:32:14.449Z" },
+    { url = "https://files.pythonhosted.org/packages/80/28/2a148a51e5907e504fa7b85490277734e6771d8844ebcc48764a15e28155/coverage-7.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:380e8e9084d8eb38db3a9176a1a4f3c0082c3806fa0dc882d1d87abc3c789247", size = 254852, upload-time = "2026-03-17T10:32:16.56Z" },
+    { url = "https://files.pythonhosted.org/packages/61/77/50e8d3d85cc0b7ebe09f30f151d670e302c7ff4a1bf6243f71dd8b0981fa/coverage-7.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e808af52a0513762df4d945ea164a24b37f2f518cbe97e03deaa0ee66139b4d6", size = 257161, upload-time = "2026-03-17T10:32:19.004Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c4/b5fd1d4b7bf8d0e75d997afd3925c59ba629fc8616f1b3aae7605132e256/coverage-7.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e301d30dd7e95ae068671d746ba8c34e945a82682e62918e41b2679acd2051a0", size = 251021, upload-time = "2026-03-17T10:32:21.344Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/66/6ea21f910e92d69ef0b1c3346ea5922a51bad4446c9126db2ae96ee24c4c/coverage-7.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:800bc829053c80d240a687ceeb927a94fd108bbdc68dfbe505d0d75ab578a882", size = 252858, upload-time = "2026-03-17T10:32:23.506Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ea/879c83cb5d61aa2a35fb80e72715e92672daef8191b84911a643f533840c/coverage-7.13.5-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:0b67af5492adb31940ee418a5a655c28e48165da5afab8c7fa6fd72a142f8740", size = 250823, upload-time = "2026-03-17T10:32:25.516Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fb/616d95d3adb88b9803b275580bdeee8bd1b69a886d057652521f83d7322f/coverage-7.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c9136ff29c3a91e25b1d1552b5308e53a1e0653a23e53b6366d7c2dcbbaf8a16", size = 255099, upload-time = "2026-03-17T10:32:27.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/25e6917c90ec1c9a56b0b26f6cad6408e5f13bb6b35d484a0d75c9cf000d/coverage-7.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cff784eef7f0b8f6cb28804fbddcfa99f89efe4cc35fb5627e3ac58f91ed3ac0", size = 250638, upload-time = "2026-03-17T10:32:29.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7b/dc1776b0464145a929deed214aef9fb1493f159b59ff3c7eeeedf91eddd0/coverage-7.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:68a4953be99b17ac3c23b6efbc8a38330d99680c9458927491d18700ef23ded0", size = 252295, upload-time = "2026-03-17T10:32:31.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fb/99cbbc56a26e07762a2740713f3c8f9f3f3106e3a3dd8cc4474954bccd34/coverage-7.13.5-cp314-cp314-win32.whl", hash = "sha256:35a31f2b1578185fbe6aa2e74cea1b1d0bbf4c552774247d9160d29b80ed56cc", size = 222360, upload-time = "2026-03-17T10:32:34.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b7/4758d4f73fb536347cc5e4ad63662f9d60ba9118cb6785e9616b2ce5d7fa/coverage-7.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:2aa055ae1857258f9e0045be26a6d62bdb47a72448b62d7b55f4820f361a2633", size = 223174, upload-time = "2026-03-17T10:32:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f2/24d84e1dfe70f8ac9fdf30d338239860d0d1d5da0bda528959d0ebc9da28/coverage-7.13.5-cp314-cp314-win_arm64.whl", hash = "sha256:1b11eef33edeae9d142f9b4358edb76273b3bfd30bc3df9a4f95d0e49caf94e8", size = 221739, upload-time = "2026-03-17T10:32:38.736Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5b/4a168591057b3668c2428bff25dd3ebc21b629d666d90bcdfa0217940e84/coverage-7.13.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10a0c37f0b646eaff7cce1874c31d1f1ccb297688d4c747291f4f4c70741cc8b", size = 220351, upload-time = "2026-03-17T10:32:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/21/1fd5c4dbfe4a58b6b99649125635df46decdfd4a784c3cd6d410d303e370/coverage-7.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b5db73ba3c41c7008037fa731ad5459fc3944cb7452fc0aa9f822ad3533c583c", size = 220612, upload-time = "2026-03-17T10:32:43.204Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fe/2a924b3055a5e7e4512655a9d4609781b0d62334fa0140c3e742926834e2/coverage-7.13.5-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:750db93a81e3e5a9831b534be7b1229df848b2e125a604fe6651e48aa070e5f9", size = 261985, upload-time = "2026-03-17T10:32:45.514Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/c8928f2bd518c45990fe1a2ab8db42e914ef9b726c975facc4282578c3eb/coverage-7.13.5-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ddb4f4a5479f2539644be484da179b653273bca1a323947d48ab107b3ed1f29", size = 264107, upload-time = "2026-03-17T10:32:47.971Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/ae/4ae35bbd9a0af9d820362751f0766582833c211224b38665c0f8de3d487f/coverage-7.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8a7a2049c14f413163e2bdabd37e41179b1d1ccb10ffc6ccc4b7a718429c607", size = 266513, upload-time = "2026-03-17T10:32:50.1Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/d326174c55af36f74eac6ae781612d9492f060ce8244b570bb9d50d9d609/coverage-7.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1c85e0b6c05c592ea6d8768a66a254bfb3874b53774b12d4c89c481eb78cb90", size = 267650, upload-time = "2026-03-17T10:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/5e/31484d62cbd0eabd3412e30d74386ece4a0837d4f6c3040a653878bfc019/coverage-7.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:777c4d1eff1b67876139d24288aaf1817f6c03d6bae9c5cc8d27b83bcfe38fe3", size = 261089, upload-time = "2026-03-17T10:32:54.544Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d8/49a72d6de146eebb0b7e48cc0f4bc2c0dd858e3d4790ab2b39a2872b62bd/coverage-7.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6697e29b93707167687543480a40f0db8f356e86d9f67ddf2e37e2dfd91a9dab", size = 263982, upload-time = "2026-03-17T10:32:56.803Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3b/0351f1bd566e6e4dd39e978efe7958bde1d32f879e85589de147654f57bb/coverage-7.13.5-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8fdf453a942c3e4d99bd80088141c4c6960bb232c409d9c3558e2dbaa3998562", size = 261579, upload-time = "2026-03-17T10:32:59.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/796a2a2f4017f554d7810f5c573449b35b1e46788424a548d4d19201b222/coverage-7.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:32ca0c0114c9834a43f045a87dcebd69d108d8ffb666957ea65aa132f50332e2", size = 265316, upload-time = "2026-03-17T10:33:01.847Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/16/d5ae91455541d1a78bc90abf495be600588aff8f6db5c8b0dae739fa39c9/coverage-7.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:8769751c10f339021e2638cd354e13adeac54004d1941119b2c96fe5276d45ea", size = 260427, upload-time = "2026-03-17T10:33:03.945Z" },
+    { url = "https://files.pythonhosted.org/packages/48/11/07f413dba62db21fb3fad5d0de013a50e073cc4e2dc4306e770360f6dfc8/coverage-7.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cec2d83125531bd153175354055cdb7a09987af08a9430bd173c937c6d0fba2a", size = 262745, upload-time = "2026-03-17T10:33:06.285Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/d792371332eb4663115becf4bad47e047d16234b1aff687b1b18c58d60ae/coverage-7.13.5-cp314-cp314t-win32.whl", hash = "sha256:0cd9ed7a8b181775459296e402ca4fb27db1279740a24e93b3b41942ebe4b215", size = 223146, upload-time = "2026-03-17T10:33:08.756Z" },
+    { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254, upload-time = "2026-03-17T10:33:11.174Z" },
+    { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276, upload-time = "2026-03-17T10:33:13.466Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/36/e27608899f9b8d4dff0617b2d9ab17ca5608956ca44461ac14ac48b44015/pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645", size = 131200, upload-time = "2026-01-27T03:59:46.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723", size = 55206, upload-time = "2026-01-27T03:59:45.137Z" },
+]
+
+[[package]]
+name = "persica"
+version = "0.1.0a5"
+source = { editable = "." }
+dependencies = [
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "black" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "networkx", specifier = ">=3.3" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "black", specifier = ">=24.8.0" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
+    { name = "ruff", specifier = ">=0.6.4" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytokens"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/24/f206113e05cb8ef51b3850e7ef88f20da6f4bf932190ceb48bd3da103e10/pytokens-0.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2a44ed93ea23415c54f3face3b65ef2b844d96aeb3455b8a69b3df6beab6acc5", size = 161522, upload-time = "2026-01-30T01:02:50.393Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/06a6bf1b90c2ed81a9c7d2544232fe5d2891d1cd480e8a1809ca354a8eb2/pytokens-0.4.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:add8bf86b71a5d9fb5b89f023a80b791e04fba57960aa790cc6125f7f1d39dfe", size = 246945, upload-time = "2026-01-30T01:02:52.399Z" },
+    { url = "https://files.pythonhosted.org/packages/69/66/f6fb1007a4c3d8b682d5d65b7c1fb33257587a5f782647091e3408abe0b8/pytokens-0.4.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:670d286910b531c7b7e3c0b453fd8156f250adb140146d234a82219459b9640c", size = 259525, upload-time = "2026-01-30T01:02:53.737Z" },
+    { url = "https://files.pythonhosted.org/packages/04/92/086f89b4d622a18418bac74ab5db7f68cf0c21cf7cc92de6c7b919d76c88/pytokens-0.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4e691d7f5186bd2842c14813f79f8884bb03f5995f0575272009982c5ac6c0f7", size = 262693, upload-time = "2026-01-30T01:02:54.871Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/7b/8b31c347cf94a3f900bdde750b2e9131575a61fdb620d3d3c75832262137/pytokens-0.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:27b83ad28825978742beef057bfe406ad6ed524b2d28c252c5de7b4a6dd48fa2", size = 103567, upload-time = "2026-01-30T01:02:56.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/92/790ebe03f07b57e53b10884c329b9a1a308648fc083a6d4a39a10a28c8fc/pytokens-0.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d70e77c55ae8380c91c0c18dea05951482e263982911fc7410b1ffd1dadd3440", size = 160864, upload-time = "2026-01-30T01:02:57.882Z" },
+    { url = "https://files.pythonhosted.org/packages/13/25/a4f555281d975bfdd1eba731450e2fe3a95870274da73fb12c40aeae7625/pytokens-0.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a58d057208cb9075c144950d789511220b07636dd2e4708d5645d24de666bdc", size = 248565, upload-time = "2026-01-30T01:02:59.912Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/bc0394b4ad5b1601be22fa43652173d47e4c9efbf0044c62e9a59b747c56/pytokens-0.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b49750419d300e2b5a3813cf229d4e5a4c728dae470bcc89867a9ad6f25a722d", size = 260824, upload-time = "2026-01-30T01:03:01.471Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/54/3e04f9d92a4be4fc6c80016bc396b923d2a6933ae94b5f557c939c460ee0/pytokens-0.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d9907d61f15bf7261d7e775bd5d7ee4d2930e04424bab1972591918497623a16", size = 264075, upload-time = "2026-01-30T01:03:04.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1b/44b0326cb5470a4375f37988aea5d61b5cc52407143303015ebee94abfd6/pytokens-0.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:ee44d0f85b803321710f9239f335aafe16553b39106384cef8e6de40cb4ef2f6", size = 103323, upload-time = "2026-01-30T01:03:05.412Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
+    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
+    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/d9/aa3f7d59a10ef6b14fe3431706f854dbf03c5976be614a9796d36326810c/ruff-0.15.10.tar.gz", hash = "sha256:d1f86e67ebfdef88e00faefa1552b5e510e1d35f3be7d423dc7e84e63788c94e", size = 4631728, upload-time = "2026-04-09T14:06:09.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/00/a1c2fdc9939b2c03691edbda290afcd297f1f389196172826b03d6b6a595/ruff-0.15.10-py3-none-linux_armv6l.whl", hash = "sha256:0744e31482f8f7d0d10a11fcbf897af272fefdfcb10f5af907b18c2813ff4d5f", size = 10563362, upload-time = "2026-04-09T14:06:21.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/15/006990029aea0bebe9d33c73c3e28c80c391ebdba408d1b08496f00d422d/ruff-0.15.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b1e7c16ea0ff5a53b7c2df52d947e685973049be1cdfe2b59a9c43601897b22e", size = 10951122, upload-time = "2026-04-09T14:06:02.236Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c0/4ac978fe874d0618c7da647862afe697b281c2806f13ce904ad652fa87e4/ruff-0.15.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:93cc06a19e5155b4441dd72808fdf84290d84ad8a39ca3b0f994363ade4cebb1", size = 10314005, upload-time = "2026-04-09T14:06:00.026Z" },
+    { url = "https://files.pythonhosted.org/packages/da/73/c209138a5c98c0d321266372fc4e33ad43d506d7e5dd817dd89b60a8548f/ruff-0.15.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83e1dd04312997c99ea6965df66a14fb4f03ba978564574ffc68b0d61fd3989e", size = 10643450, upload-time = "2026-04-09T14:05:42.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/76/0deec355d8ec10709653635b1f90856735302cb8e149acfdf6f82a5feb70/ruff-0.15.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8154d43684e4333360fedd11aaa40b1b08a4e37d8ffa9d95fee6fa5b37b6fab1", size = 10379597, upload-time = "2026-04-09T14:05:49.984Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/be/86bba8fc8798c081e28a4b3bb6d143ccad3fd5f6f024f02002b8f08a9fa3/ruff-0.15.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8ab88715f3a6deb6bde6c227f3a123410bec7b855c3ae331b4c006189e895cef", size = 11146645, upload-time = "2026-04-09T14:06:12.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/89/140025e65911b281c57be1d385ba1d932c2366ca88ae6663685aed8d4881/ruff-0.15.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a768ff5969b4f44c349d48edf4ab4f91eddb27fd9d77799598e130fb628aa158", size = 12030289, upload-time = "2026-04-09T14:06:04.776Z" },
+    { url = "https://files.pythonhosted.org/packages/88/de/ddacca9545a5e01332567db01d44bd8cf725f2db3b3d61a80550b48308ea/ruff-0.15.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ee3ef42dab7078bda5ff6a1bcba8539e9857deb447132ad5566a038674540d0", size = 11496266, upload-time = "2026-04-09T14:05:55.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bb/7ddb00a83760ff4a83c4e2fc231fd63937cc7317c10c82f583302e0f6586/ruff-0.15.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51cb8cc943e891ba99989dd92d61e29b1d231e14811db9be6440ecf25d5c1609", size = 11256418, upload-time = "2026-04-09T14:05:57.69Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8d/55de0d35aacf6cd50b6ee91ee0f291672080021896543776f4170fc5c454/ruff-0.15.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e59c9bdc056a320fb9ea1700a8d591718b8faf78af065484e801258d3a76bc3f", size = 11288416, upload-time = "2026-04-09T14:05:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/68/cf/9438b1a27426ec46a80e0a718093c7f958ef72f43eb3111862949ead3cc1/ruff-0.15.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:136c00ca2f47b0018b073f28cb5c1506642a830ea941a60354b0e8bc8076b151", size = 10621053, upload-time = "2026-04-09T14:05:52.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/50/e29be6e2c135e9cd4cb15fbade49d6a2717e009dff3766dd080fcb82e251/ruff-0.15.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8b80a2f3c9c8a950d6237f2ca12b206bccff626139be9fa005f14feb881a1ae8", size = 10378302, upload-time = "2026-04-09T14:06:14.361Z" },
+    { url = "https://files.pythonhosted.org/packages/18/2f/e0b36a6f99c51bb89f3a30239bc7bf97e87a37ae80aa2d6542d6e5150364/ruff-0.15.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e3e53c588164dc025b671c9df2462429d60357ea91af7e92e9d56c565a9f1b07", size = 10850074, upload-time = "2026-04-09T14:06:16.581Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/874da392558ce087a0f9b709dc6ec0d60cbc694c1c772dab8d5f31efe8cb/ruff-0.15.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b0c52744cf9f143a393e284125d2576140b68264a93c6716464e129a3e9adb48", size = 11358051, upload-time = "2026-04-09T14:06:18.948Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/46/602938f030adfa043e67112b73821024dc79f3ab4df5474c25fa4c1d2d14/ruff-0.15.10-py3-none-win32.whl", hash = "sha256:d4272e87e801e9a27a2e8df7b21011c909d9ddd82f4f3281d269b6ba19789ca5", size = 10588964, upload-time = "2026-04-09T14:06:07.14Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b6/261225b875d7a13b33a6d02508c39c28450b2041bb01d0f7f1a83d569512/ruff-0.15.10-py3-none-win_amd64.whl", hash = "sha256:28cb32d53203242d403d819fd6983152489b12e4a3ae44993543d6fe62ab42ed", size = 11745044, upload-time = "2026-04-09T14:05:39.473Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ed/dea90a65b7d9e69888890fb14c90d7f51bf0c1e82ad800aeb0160e4bacfd/ruff-0.15.10-py3-none-win_arm64.whl", hash = "sha256:601d1610a9e1f1c2165a4f561eeaa2e2ea1e97f3287c5aa258d3dab8b57c6188", size = 11035607, upload-time = "2026-04-09T14:05:47.593Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
## Summary
- isolate factory and registry state so scanning, registration, and repeated flashes stay bounded to the active scan root
- make dependency injection, factory selection, and async application lifecycle behavior deterministic across modern asyncio runtimes
- add regression coverage for scanner boundaries, lifecycle edge cases, and factory resolution while updating uv/project verification docs

## Test Plan
- [x] `uv run ruff check`
- [x] `uv run pytest`
- [x] `uv build`