### PR TITLE
:sparkles: Add developer-friendly injection APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,59 @@ class HelloComponent(AsyncInitializingComponent):
         print("Persica stopped")
 ```
 
+App-level resources can be published through `Application.provide_objects()` and injected the same way as component-published resources. They are available as soon as the app is built, before `run()` starts creating components.
+
+```python
+# example_app/application.py
+from persica import inject
+from persica.application import Application
+from persica.applicationbuilder import ApplicationBuilder
+
+
+class GreetingService:
+    def greet(self) -> str:
+        return "hello from the application"
+
+
+class ExampleApplication(Application):
+    def __init__(self, *args, **kwargs):
+        self.greeting_service = GreetingService()
+        super().__init__(*args, **kwargs)
+
+    def provide_objects(self) -> list[GreetingService]:
+        return [self.greeting_service]
+
+
+class ExampleApplicationBuilder(ApplicationBuilder):
+    _application_class = ExampleApplication
+```
+
+```python
+# example_app/components.py
+from persica import inject
+from persica.factory.component import AsyncInitializingComponent
+
+from example_app.application import ExampleApplicationBuilder, GreetingService
+
+
+class GreetingPrinter(AsyncInitializingComponent):
+    greeting_service: GreetingService = inject()
+
+    async def initialize(self):
+        print(self.greeting_service.greet())
+```
+
+```python
+# example_app/main.py
+from example_app.application import ExampleApplicationBuilder
+
+
+app = ExampleApplicationBuilder().set_scanner_package("example_app").build()
+
+# build() is still synchronous; run() starts initialization and blocks.
+app.run()
+```
+
 ## Future
 - [ ] Support full path scanning
 - [ ] Support custom factory assembly

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -17,6 +17,87 @@
 本框架的设计灵感来源于 [spring-framework](https://github.com/spring-projects/)
 特别是对于其强大的自动装配功能受到震撼。
 
+## 快速开始
+
+`build()` 是同步的，只负责构造应用对象。`run()` 会使用已配置的事件循环；如果没有提供，就在运行时自行创建，并在应用停止前持续运行。如果你传入了自己的事件循环，它不能已经处于运行状态。
+
+```python
+from persica.applicationbuilder import ApplicationBuilder
+
+app = ApplicationBuilder().set_scanner_package("example_app").build()
+
+# 会一直阻塞到应用停止，例如按下 Ctrl+C。
+app.run()
+```
+
+```python
+# example_app/components.py
+from persica.factory.component import AsyncInitializingComponent
+
+
+class HelloComponent(AsyncInitializingComponent):
+    async def initialize(self):
+        print("Persica is running")
+
+    async def shutdown(self):
+        print("Persica stopped")
+```
+
+## 应用级资源发布
+
+应用对象可以通过 `Application.provide_objects()` 发布运行时资源，这些资源会和组件发布的资源一样参与注入。它们在 `build()` 完成后就已经可用，不需要等到 `run()` 开始。
+
+```python
+# example_app/application.py
+from persica import inject
+from persica.application import Application
+from persica.applicationbuilder import ApplicationBuilder
+
+
+class GreetingService:
+    def greet(self) -> str:
+        return "hello from the application"
+
+
+class ExampleApplication(Application):
+    def __init__(self, *args, **kwargs):
+        self.greeting_service = GreetingService()
+        super().__init__(*args, **kwargs)
+
+    def provide_objects(self) -> list[GreetingService]:
+        return [self.greeting_service]
+
+
+class ExampleApplicationBuilder(ApplicationBuilder):
+    _application_class = ExampleApplication
+```
+
+```python
+# example_app/components.py
+from persica import inject
+from persica.factory.component import AsyncInitializingComponent
+
+from example_app.application import GreetingService
+
+
+class GreetingPrinter(AsyncInitializingComponent):
+    greeting_service: GreetingService = inject()
+
+    async def initialize(self):
+        print(self.greeting_service.greet())
+```
+
+```python
+# example_app/main.py
+from example_app.application import ExampleApplicationBuilder
+
+
+app = ExampleApplicationBuilder().set_scanner_package("example_app").build()
+
+# build() 仍然是同步的；run() 负责启动初始化并阻塞运行。
+app.run()
+```
+
 ## Future
 - [ ] 支持完整路径扫描
 - [ ] 支持自定义工厂装配

--- a/persica/__init__.py
+++ b/persica/__init__.py
@@ -1,0 +1,4 @@
+from persica.injection import inject, inject_all, inject_map
+from persica.phase import Phase
+
+__all__ = ["Phase", "inject", "inject_all", "inject_map"]

--- a/persica/application.py
+++ b/persica/application.py
@@ -38,6 +38,10 @@ class Application:
         self.context = context_class(factory=self.factory, class_scanner=self.class_scanner, registry=self.registry)
         self.factory.add_external_object(self.context)
         self.factory.add_external_object(self)
+        self.factory._publish_objects(self)
+
+    def provide_objects(self) -> list[object]:
+        return []
 
     def run(self) -> None:
         self._logger.info("Application Run")

--- a/persica/error.py
+++ b/persica/error.py
@@ -4,3 +4,10 @@ class NoSuchParameterException(Exception):
 
 class AmbiguousDependencyException(Exception):
     pass
+
+
+class InvalidInjectionConfigurationError(Exception):
+    pass
+
+
+InvalidInjectionConfigurationException = InvalidInjectionConfigurationError

--- a/persica/factory/abstract.py
+++ b/persica/factory/abstract.py
@@ -1,16 +1,24 @@
 import inspect
+import re
+import sys
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, get_args, get_origin
 
-from persica.error import AmbiguousDependencyException, NoSuchParameterException
+from persica.error import (
+    AmbiguousDependencyException,
+    InvalidInjectionConfigurationError,
+    NoSuchParameterException,
+)
 from persica.factory.definition import ObjectDefinition
 from persica.factory.interface import InterfaceFactory
+from persica.injection import InjectionMarker
 from persica.utils.logging import get_logger
 
 if TYPE_CHECKING:
     from logging import Logger
 
 _LOGGER = get_logger(__name__, "AbstractAutowireCapableFactory")
+MAP_INJECTION_ARGUMENT_COUNT = 2
 
 
 class AbstractAutowireCapableFactory:
@@ -27,6 +35,12 @@ class AbstractAutowireCapableFactory:
     singleton_factories: dict[type[InterfaceFactory], InterfaceFactory]
     # 存储外部可注入的对象，key 为对象的类，value 为对象实例
     external_objects: dict[type[object], object]
+    # 存储运行时发布的可注入对象，key 为对象的类，value 为对象实例
+    published_objects: dict[type[object], list[object]]
+    # 按实际发布时间顺序存储运行时发布的可注入对象
+    published_object_sequence: list[object]
+    # 存储当前正在创建的对象类型，避免按需发布时递归回到自身
+    creating_classes: set[type[object]]
 
     def __init__(self, external_objects: Iterable[object] | None = None):
         """
@@ -38,6 +52,9 @@ class AbstractAutowireCapableFactory:
         self.singleton_objects = {}
         self.singleton_factories = {}
         self.external_objects = {}
+        self.published_objects = {}
+        self.published_object_sequence = []
+        self.creating_classes = set()
 
         if external_objects is not None:
             for obj in external_objects:
@@ -92,24 +109,506 @@ class AbstractAutowireCapableFactory:
         """
         self._logger.info("Creating object %s", cls.__name__)
         definition = self.object_definitions.get(cls)
-        # 查找是否有该类的工厂
-        factory = self._find_factory_for_class(cls)
-        # 构建构造函数参数
-        params = self._build_constructor_params(cls)
-        # 创建对象
-        obj = cls(**params)
-        # 如果该类有工厂管理，则通过工厂获取实例
-        if factory is not None:
-            instance = factory.get_object(obj)
-            if instance is not None:
-                self.singleton_objects[cls] = instance
+        self.creating_classes.add(cls)
+        try:
+            # 查找是否有该类的工厂
+            factory = self._find_factory_for_class(cls)
+            # 构建构造函数参数
+            params = self._build_constructor_params(cls)
+            # 创建对象
+            obj = cls(**params)
+            instance = obj
+            # 如果该类有工厂管理，则通过工厂获取实例
+            if factory is not None:
+                factory_instance = factory.get_object(obj)
+                if factory_instance is not None:
+                    instance = factory_instance
+            self._finalize_created_object(obj)
+            # 如果没有工厂管理，直接返回对象
+            if definition is not None and definition.is_factory:
+                self.singleton_factories[cast("type[InterfaceFactory]", cls)] = cast("InterfaceFactory", instance)
                 return instance
-        # 如果没有工厂管理，直接返回对象
-        if definition is not None and definition.is_factory:
-            self.singleton_factories[cast("type[InterfaceFactory]", cls)] = cast("InterfaceFactory", obj)
-            return obj
-        self.singleton_objects[cls] = obj
-        return obj
+            self.singleton_objects[cls] = instance
+            return instance
+        finally:
+            self.creating_classes.discard(cls)
+
+    def _finalize_created_object(self, obj: object):
+        self._inject_marked_properties(obj)
+        published_objects = self._publish_objects(obj)
+        try:
+            after_inject = getattr(obj, "after_inject", None)
+            if callable(after_inject):
+                after_inject()
+        except Exception:
+            self._rollback_published_objects(published_objects)
+            raise
+
+    def _inject_marked_properties(self, obj: object):
+        for name, annotation, marker in self._iter_injection_markers(obj.__class__):
+            dependency = self._resolve_marked_property(obj.__class__, name, annotation, marker)
+            setattr(obj, name, dependency)
+
+    def _resolve_marked_property(
+        self,
+        cls: type[object],
+        name: str,
+        annotation: Any,
+        marker: InjectionMarker,
+    ) -> object:
+        if marker.kind == "single":
+            if not isinstance(annotation, type):
+                raise InvalidInjectionConfigurationError(
+                    f"Injected property {cls.__name__}.{name} must declare a concrete type annotation"
+                )
+            dependency = self._resolve_dependency(annotation, name)
+            if dependency is None:
+                raise NoSuchParameterException(
+                    f"Cannot find the {name} property of type {annotation.__name__} required "
+                    f"by the {cls.__name__} component"
+                )
+            return dependency
+
+        if marker.kind == "all":
+            dependency_type = self._extract_collection_injection_type(cls, name, annotation)
+            return self._collect_compatible_objects(dependency_type)
+
+        if marker.kind == "map":
+            key_type, dependency_type = self._extract_map_injection_types(cls, name, annotation)
+            dependencies_by_key: dict[object, object] = {}
+            for dependency in self._collect_compatible_objects(dependency_type):
+                if marker.key_attr is None or not hasattr(dependency, marker.key_attr):
+                    raise InvalidInjectionConfigurationError(
+                        f"Injected property {cls.__name__}.{name} requires key attribute {marker.key_attr!r} "
+                        f"on {dependency.__class__.__name__}"
+                    )
+                key = getattr(dependency, marker.key_attr)
+                if key is None:
+                    raise InvalidInjectionConfigurationError(
+                        f"Injected property {cls.__name__}.{name} resolved a None key from attribute "
+                        f"{marker.key_attr!r} on {dependency.__class__.__name__}"
+                    )
+                if not isinstance(key, key_type):
+                    raise InvalidInjectionConfigurationError(
+                        f"Injected property {cls.__name__}.{name} resolved key {key!r} of type "
+                        f"{key.__class__.__name__}, expected {key_type.__name__}"
+                    )
+                if key in dependencies_by_key:
+                    raise InvalidInjectionConfigurationError(
+                        f"Injected property {cls.__name__}.{name} resolved duplicate key {key!r} from "
+                        f"attribute {marker.key_attr!r}"
+                    )
+                dependencies_by_key[key] = dependency
+            return dependencies_by_key
+
+        raise InvalidInjectionConfigurationError(f"Unsupported injection kind {marker.kind!r} on {cls.__name__}.{name}")
+
+    def _iter_injection_markers(self, cls: type[object]) -> Iterable[tuple[str, Any, InjectionMarker]]:
+        markers: list[tuple[str, Any, InjectionMarker]] = []
+        seen_names: set[str] = set()
+        for current_cls in cls.__mro__:
+            for name, value in list(vars(current_cls).items()):
+                if name in seen_names:
+                    continue
+                seen_names.add(name)
+                if not isinstance(value, InjectionMarker):
+                    continue
+                annotation = self._resolve_effective_injected_annotation(cls, current_cls, name)
+                markers.append((name, annotation, value))
+        yield from reversed(markers)
+
+    def _resolve_effective_injected_annotation(
+        self, target_cls: type[object], marker_owner_cls: type[object], name: str
+    ) -> Any:
+        for current_cls in target_cls.__mro__:
+            if name in getattr(current_cls, "__annotations__", {}):
+                return self._resolve_class_annotation(current_cls, name)
+            if current_cls is marker_owner_cls:
+                break
+        return self._resolve_class_annotation(marker_owner_cls, name)
+
+    def _extract_collection_injection_type(self, cls: type[object], name: str, annotation: Any) -> type[object]:
+        origin = get_origin(annotation)
+        arguments = get_args(annotation)
+        if origin is not list or len(arguments) != 1 or not isinstance(arguments[0], type):
+            raise InvalidInjectionConfigurationError(
+                f"Injected property {cls.__name__}.{name} using inject_all() must declare a list[T] annotation"
+            )
+        return cast("type[object]", arguments[0])
+
+    def _extract_map_injection_types(
+        self, cls: type[object], name: str, annotation: Any
+    ) -> tuple[type[object], type[object]]:
+        origin = get_origin(annotation)
+        arguments = get_args(annotation)
+        if (
+            origin is not dict
+            or len(arguments) != MAP_INJECTION_ARGUMENT_COUNT
+            or not isinstance(arguments[0], type)
+            or not isinstance(arguments[1], type)
+        ):
+            raise InvalidInjectionConfigurationError(
+                f"Injected property {cls.__name__}.{name} using inject_map() must declare a dict[K, V] annotation"
+            )
+        return cast("type[object]", arguments[0]), cast("type[object]", arguments[1])
+
+    def _collect_compatible_objects(self, annotation: type[object]) -> list[object]:
+        candidate_publishers = self._find_candidate_publishers(
+            annotation,
+            exact_match=False,
+            allow_declared_supertypes=False,
+        )
+        for publisher_cls in candidate_publishers:
+            self.get_object(publisher_cls)
+
+        collected: list[object] = []
+        seen_ids: set[int] = set()
+
+        def add_candidate(candidate: object):
+            candidate_id = id(candidate)
+            if candidate_id in seen_ids:
+                return
+            seen_ids.add(candidate_id)
+            collected.append(candidate)
+
+        for instance in self.singleton_objects.values():
+            if isinstance(instance, annotation):
+                add_candidate(instance)
+
+        for instance in self.external_objects.values():
+            if isinstance(instance, annotation):
+                add_candidate(instance)
+
+        for instance in self.published_object_sequence:
+            if isinstance(instance, annotation):
+                add_candidate(instance)
+
+        for definition in self._iter_ordered_definitions():
+            candidate_cls = definition.class_object
+            if definition.is_factory or candidate_cls in self.creating_classes:
+                continue
+            if issubclass(candidate_cls, annotation):
+                instance = self.get_object(definition.class_object)
+                if isinstance(instance, annotation):
+                    add_candidate(instance)
+
+        return collected
+
+    def _resolve_class_annotation(self, cls: type[object], name: str) -> Any:
+        annotations = getattr(cls, "__annotations__", {})
+        annotation = annotations.get(name)
+        return self._resolve_annotation(
+            annotation,
+            globals_namespace=vars(sys.modules[cls.__module__]),
+            locals_namespace=dict(vars(cls)),
+            error_context=f"Injected property {cls.__name__}.{name}",
+        )
+
+    def _resolve_annotation(
+        self,
+        annotation: Any,
+        *,
+        globals_namespace: dict[str, Any],
+        locals_namespace: dict[str, Any],
+        error_context: str,
+        suppress_resolution_errors: bool = False,
+    ) -> Any:
+        if not isinstance(annotation, str):
+            return annotation
+
+        try:
+            return eval(annotation, globals_namespace, locals_namespace)  # noqa: S307
+        except Exception as exc:
+            if suppress_resolution_errors:
+                return None
+            raise InvalidInjectionConfigurationError(
+                f"{error_context} has an unresolved annotation: {annotation}"
+            ) from exc
+
+    def _publish_objects(self, obj: object) -> list[object]:
+        provide_objects = getattr(obj, "provide_objects", None)
+        if not callable(provide_objects):
+            return []
+        published = provide_objects()
+        if published is None:
+            return []
+        if not isinstance(published, list):
+            raise InvalidInjectionConfigurationError(
+                f"{obj.__class__.__name__}.provide_objects() must return a list of objects"
+            )
+        for published_object in published:
+            self.published_objects.setdefault(published_object.__class__, []).append(published_object)
+            self.published_object_sequence.append(published_object)
+        return list(published)
+
+    def _rollback_published_objects(self, published_objects: list[object]):
+        for published_object in reversed(published_objects):
+            published_instances = self.published_objects.get(published_object.__class__)
+            if published_instances is not None:
+                for index in range(len(published_instances) - 1, -1, -1):
+                    if published_instances[index] is published_object:
+                        del published_instances[index]
+                        break
+                if not published_instances:
+                    del self.published_objects[published_object.__class__]
+            for index in range(len(self.published_object_sequence) - 1, -1, -1):
+                if self.published_object_sequence[index] is published_object:
+                    del self.published_object_sequence[index]
+                    break
+
+    def _iter_ordered_definitions(self) -> Iterable[ObjectDefinition]:
+        yielded_classes: set[type[object]] = set()
+        for _, definitions in sorted(self.order_definitions.items()):
+            for definition in definitions:
+                yielded_classes.add(definition.class_object)
+                yield definition
+        for definition in self.object_definitions.values():
+            if definition.class_object in yielded_classes:
+                continue
+            yield definition
+
+    def _resolve_published_dependency(self, annotation: type[object], parameter_name: str) -> object | None:
+        dependency = self._resolve_exact_published_object(annotation, parameter_name)
+        if dependency is not None:
+            return dependency
+
+        candidate_publishers = self._find_candidate_publishers(
+            annotation,
+            exact_match=True,
+            allow_declared_supertypes=False,
+        )
+        if not candidate_publishers:
+            return None
+
+        for publisher_cls in candidate_publishers:
+            self.get_object(publisher_cls)
+        return self._resolve_exact_published_object(annotation, parameter_name)
+
+    def _resolve_exact_published_object(self, annotation: type[object], parameter_name: str) -> object | None:
+        exact_published = self.published_objects.get(annotation)
+        if exact_published is not None:
+            if len(exact_published) > 1:
+                raise AmbiguousDependencyException(
+                    f"Multiple compatible dependencies found for parameter {parameter_name} of type "
+                    f"{annotation.__name__}: {', '.join(obj.__class__.__name__ for obj in exact_published)}"
+                )
+            return exact_published[0]
+
+        return None
+
+    def _resolve_compatible_published_dependency(self, annotation: type[object], parameter_name: str) -> object | None:
+        dependency = self._resolve_compatible_published_object(annotation, parameter_name)
+        if dependency is not None:
+            return dependency
+
+        candidate_publishers = self._find_candidate_publishers(
+            annotation,
+            exact_match=False,
+            allow_declared_supertypes=False,
+        )
+        if not candidate_publishers:
+            return None
+
+        for publisher_cls in candidate_publishers:
+            self.get_object(publisher_cls)
+        return self._resolve_compatible_published_object(annotation, parameter_name)
+
+    def _resolve_compatible_published_object(self, annotation: type[object], parameter_name: str) -> object | None:
+        compatible_published = {
+            candidate_cls: instances
+            for candidate_cls, instances in self.published_objects.items()
+            if issubclass(candidate_cls, annotation)
+        }
+        compatible_count = sum(len(instances) for instances in compatible_published.values())
+        if compatible_count > 1:
+            raise AmbiguousDependencyException(
+                f"Multiple compatible dependencies found for parameter {parameter_name} of type "
+                f"{annotation.__name__}: {', '.join(candidate_cls.__name__ for candidate_cls, instances in compatible_published.items() for _ in instances)}"
+            )
+        if compatible_published:
+            return next(iter(compatible_published.values()))[0]
+        return None
+
+    def _find_candidate_publishers(
+        self,
+        annotation: type[object],
+        *,
+        exact_match: bool,
+        allow_declared_supertypes: bool = True,
+    ) -> list[type[object]]:
+        candidate_publishers: list[type[object]] = []
+        for definition in self._iter_ordered_definitions():
+            publisher_cls = definition.class_object
+            if (
+                definition.is_factory
+                or publisher_cls in self.singleton_objects
+                or publisher_cls in self.creating_classes
+            ):
+                continue
+            published_types, unresolved_error, unresolved_annotation = self._get_published_types(publisher_cls)
+            if unresolved_error is not None and self._is_relevant_unresolved_publisher_annotation(
+                annotation,
+                unresolved_annotation,
+                exact_match=exact_match,
+                allow_declared_supertypes=allow_declared_supertypes,
+            ):
+                raise unresolved_error
+            if exact_match and any(published_type == annotation for published_type in published_types):
+                candidate_publishers.append(publisher_cls)
+                continue
+            if not exact_match and any(
+                issubclass(published_type, annotation)
+                or (
+                    allow_declared_supertypes
+                    and published_type is not object
+                    and issubclass(annotation, published_type)
+                )
+                for published_type in published_types
+            ):
+                candidate_publishers.append(publisher_cls)
+        return candidate_publishers
+
+    def _get_published_types(
+        self, cls: type[object]
+    ) -> tuple[tuple[type[object], ...], InvalidInjectionConfigurationError | None, str | None]:
+        provide_objects = getattr(cls, "provide_objects", None)
+        if not callable(provide_objects):
+            return (), None, None
+
+        try:
+            signature = inspect.signature(provide_objects, eval_str=False)
+        except ValueError:
+            return (), None, None
+
+        raw_return_annotation = signature.return_annotation
+
+        resolved_return_annotation = self._resolve_annotation(
+            raw_return_annotation,
+            globals_namespace=provide_objects.__globals__,
+            locals_namespace=dict(vars(cls)),
+            error_context=f"{cls.__name__}.provide_objects() return annotation",
+            suppress_resolution_errors=True,
+        )
+        if resolved_return_annotation is None and isinstance(raw_return_annotation, str):
+            unresolved_error = InvalidInjectionConfigurationError(
+                f"{cls.__name__}.provide_objects() return annotation has an unresolved annotation: {raw_return_annotation}"
+            )
+            return (), unresolved_error, raw_return_annotation
+
+        return self._extract_published_types(resolved_return_annotation), None, None
+
+    def _is_relevant_unresolved_publisher_annotation(
+        self,
+        annotation: type[object],
+        unresolved_annotation: str | None,
+        *,
+        exact_match: bool,
+        allow_declared_supertypes: bool,
+    ) -> bool:
+        if unresolved_annotation is None:
+            return False
+        candidate_types = {annotation}
+        if not exact_match:
+            candidate_types.update(self._iter_subclasses(annotation))
+            candidate_types.update(
+                candidate_cls
+                for candidate_cls in self.object_definitions
+                if candidate_cls is not annotation and issubclass(candidate_cls, annotation)
+            )
+            candidate_types.update(
+                candidate_cls
+                for candidate_cls in self.published_objects
+                if candidate_cls is not annotation and issubclass(candidate_cls, annotation)
+            )
+        if allow_declared_supertypes:
+            candidate_types.update(base for base in annotation.__mro__[1:] if base is not object)
+            candidate_types.update(
+                base
+                for candidate_cls in self.object_definitions
+                if candidate_cls is not annotation and issubclass(candidate_cls, annotation)
+                for base in candidate_cls.__mro__[1:]
+                if base is not object
+            )
+            candidate_types.update(
+                base
+                for candidate_cls in self.published_objects
+                if candidate_cls is not annotation and issubclass(candidate_cls, annotation)
+                for base in candidate_cls.__mro__[1:]
+                if base is not object
+            )
+
+        unresolved_dotted_type_names = set(
+            re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)+\b", unresolved_annotation)
+        )
+        unresolved_simple_type_names = set(re.findall(r"\b[A-Za-z_][A-Za-z0-9_]*\b", unresolved_annotation))
+
+        known_types = set(candidate_types)
+        known_types.update(self.object_definitions)
+        known_types.update(self.published_objects)
+        for candidate_type in candidate_types:
+            known_types.update(self._iter_module_visible_types(candidate_type.__module__))
+
+        simple_name_counts: dict[str, int] = {}
+        for known_type in known_types:
+            simple_name_counts[known_type.__name__] = simple_name_counts.get(known_type.__name__, 0) + 1
+
+        precise_candidate_names = {
+            name
+            for candidate_type in candidate_types
+            for name in (candidate_type.__qualname__, f"{candidate_type.__module__}.{candidate_type.__qualname__}")
+        }
+        if precise_candidate_names & unresolved_dotted_type_names:
+            return True
+
+        unique_simple_candidate_names = {
+            candidate_type.__name__
+            for candidate_type in candidate_types
+            if simple_name_counts.get(candidate_type.__name__) == 1
+        }
+        return bool(unique_simple_candidate_names & unresolved_simple_type_names)
+
+    def _iter_module_visible_types(self, module_name: str) -> set[type[object]]:
+        module = sys.modules.get(module_name)
+        if module is None:
+            return set()
+
+        discovered: set[type[object]] = set()
+        for value in vars(module).values():
+            if not isinstance(value, type):
+                continue
+            discovered.add(value)
+            for nested_value in vars(value).values():
+                if isinstance(nested_value, type):
+                    discovered.add(nested_value)
+        return discovered
+
+    def _iter_subclasses(self, annotation: type[object]) -> set[type[object]]:
+        discovered: set[type[object]] = set()
+        pending = list(annotation.__subclasses__())
+        while pending:
+            subclass = pending.pop()
+            if subclass in discovered:
+                continue
+            discovered.add(subclass)
+            pending.extend(subclass.__subclasses__())
+        return discovered
+
+    def _extract_published_types(self, annotation: Any) -> tuple[type[object], ...]:
+        if annotation in (inspect.Signature.empty, None):
+            return ()
+        if isinstance(annotation, type):
+            return (annotation,)
+
+        origin = get_origin(annotation)
+        if origin is None:
+            return ()
+
+        extracted: list[type[object]] = []
+        for argument in get_args(annotation):
+            if argument is Ellipsis:
+                continue
+            extracted.extend(self._extract_published_types(argument))
+        return tuple(extracted)
 
     def _find_factory_for_class(self, cls: type[object]) -> InterfaceFactory | None:
         """
@@ -197,6 +696,10 @@ class AbstractAutowireCapableFactory:
         if exact_definition is not None:
             return self.get_object(exact_definition.class_object)
 
+        published_dependency = self._resolve_published_dependency(annotation, parameter_name)
+        if published_dependency is not None:
+            return published_dependency
+
         compatible_candidates: dict[type[object], tuple[str, object | ObjectDefinition]] = {}
         for candidate_cls, instance in self.singleton_objects.items():
             if issubclass(candidate_cls, annotation):
@@ -214,7 +717,7 @@ class AbstractAutowireCapableFactory:
                 f"{annotation.__name__}: {', '.join(candidate_cls.__name__ for candidate_cls in compatible_candidates)}"
             )
         if not compatible_candidates:
-            return None
+            return self._resolve_compatible_published_dependency(annotation, parameter_name)
 
         _, (source, value) = next(iter(compatible_candidates.items()))
         if source == "definition":

--- a/persica/factory/component.py
+++ b/persica/factory/component.py
@@ -1,14 +1,29 @@
+from persica.phase import Phase
+
 DEFAULT_ORDER: int = 0
 
 
 class BaseComponent:
     __order__: int = DEFAULT_ORDER
+    __phase__: Phase | None = None
 
     def __init_subclass__(cls, **kwargs):
         order = kwargs.pop("order", None)
+        phase = kwargs.pop("phase", None)
         super().__init_subclass__(**kwargs)
+
+        if phase is not None and order is not None:
+            raise TypeError("BaseComponent subclasses cannot define both phase and order")
+
+        if phase is not None and not isinstance(phase, Phase):
+            raise TypeError("BaseComponent phase must be a Phase enum value")
+
         if order is not None:
             cls.__order__ = order
+            cls.__phase__ = None
+        elif phase is not None:
+            cls.__order__ = int(phase)
+            cls.__phase__ = phase
 
 
 class AsyncInitializingComponent(BaseComponent):

--- a/persica/factory/registry.py
+++ b/persica/factory/registry.py
@@ -32,6 +32,10 @@ class DefinitionRegistry:
         self.factory.factory_cache = {}
         self.factory.singleton_objects = {}
         self.factory.singleton_factories = {}
+        self.factory.published_objects = {}
+        self.factory.published_object_sequence = []
+        for external_object in self.factory.external_objects.values():
+            self.factory._publish_objects(external_object)
         self._import_module()
         self._registry_class()
         self._check_class()

--- a/persica/injection.py
+++ b/persica/injection.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class InjectionMarker:
+    kind: str
+    key_attr: str | None = None
+
+
+def inject() -> InjectionMarker:
+    return InjectionMarker(kind="single")
+
+
+def inject_all() -> InjectionMarker:
+    return InjectionMarker(kind="all")
+
+
+def inject_map(key_attr: str) -> InjectionMarker:
+    return InjectionMarker(kind="map", key_attr=key_attr)

--- a/persica/phase.py
+++ b/persica/phase.py
@@ -1,0 +1,9 @@
+from enum import IntEnum
+
+
+class Phase(IntEnum):
+    DEPENDENCY = 10
+    REPOSITORY = 20
+    SERVICE = 30
+    COMMAND = 40
+    JOB = 50

--- a/tests/context/test_application.py
+++ b/tests/context/test_application.py
@@ -1,5 +1,51 @@
 import asyncio
 
+from persica import inject
+from persica.application import Application
+from persica.context.application import ApplicationContext
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.definition import ObjectDefinition
+from persica.factory.registry import DefinitionRegistry
+from persica.scanner.path import ClassPathScanner
+from tests.repeated_run_publish_package.components import RepeatedRunPublishedResourceConsumer
+from tests.repeated_run_publish_package.shared import RepeatedRunPublishedResource
+
+
+class _NoOpScanner:
+    def flash(self) -> None:
+        return None
+
+
+class _NoOpRegistry:
+    def flash(self) -> None:
+        return None
+
+
+class AppPublishedResource:
+    pass
+
+
+class AppPublishedResourceConsumer:
+    resource: AppPublishedResource = inject()
+
+
+class PublishingApplication(Application):
+    def __init__(self, *args, **kwargs):
+        self.resource = AppPublishedResource()
+        super().__init__(*args, **kwargs)
+
+    def provide_objects(self) -> list[AppPublishedResource]:
+        return [self.resource]
+
+
+class RepeatedPublishingApplication(Application):
+    def __init__(self, *args, **kwargs):
+        self.resource = RepeatedRunPublishedResource("first")
+        super().__init__(*args, **kwargs)
+
+    def provide_objects(self) -> list[RepeatedRunPublishedResource]:
+        return [self.resource]
+
 
 class TestApplicationContext:
     async def test_initialize_and_shutdown(self, app):
@@ -8,3 +54,62 @@ class TestApplicationContext:
         await loop.run_in_executor(None, context.run)
         await context.initialize()
         await context.shutdown()
+
+
+def test_application_provide_objects_defaults_to_empty_list():
+    app = Application(
+        factory=AbstractAutowireCapableFactory(),
+        class_scanner=_NoOpScanner(),
+        registry=_NoOpRegistry(),
+        context_class=ApplicationContext,
+    )
+
+    assert app.provide_objects() == []
+
+
+def test_application_publishes_resources_for_component_injection():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        AppPublishedResourceConsumer: ObjectDefinition(class_object=AppPublishedResourceConsumer)
+    }
+    app = PublishingApplication(
+        factory=factory,
+        class_scanner=_NoOpScanner(),
+        registry=_NoOpRegistry(),
+        context_class=ApplicationContext,
+    )
+
+    consumer = factory.create_object(AppPublishedResourceConsumer)
+
+    assert consumer.resource is app.resource
+    assert factory.published_objects == {AppPublishedResource: [app.resource]}
+    assert factory.published_object_sequence == [app.resource]
+
+
+def test_context_run_replaces_application_published_resources_between_runs():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=["tests.repeated_run_publish_package"])
+    registry = DefinitionRegistry(factory, scanner)
+    app = RepeatedPublishingApplication(
+        factory=factory,
+        class_scanner=scanner,
+        registry=registry,
+        context_class=ApplicationContext,
+    )
+
+    app.context.run()
+
+    first_consumer = factory.singleton_objects[RepeatedRunPublishedResourceConsumer]
+    first_resource = app.resource
+    assert first_consumer.resource is first_resource
+
+    app.resource = RepeatedRunPublishedResource("second")
+
+    app.context.run()
+
+    second_consumer = factory.singleton_objects[RepeatedRunPublishedResourceConsumer]
+    assert second_consumer is not first_consumer
+    assert second_consumer.resource is app.resource
+    assert second_consumer.resource is not first_resource
+    assert factory.published_objects == {RepeatedRunPublishedResource: [app.resource]}
+    assert factory.published_object_sequence == [app.resource]

--- a/tests/factory/test_factory_state.py
+++ b/tests/factory/test_factory_state.py
@@ -1,3 +1,4 @@
+from persica import Phase
 from persica.factory.abstract import AbstractAutowireCapableFactory
 from persica.factory.component import BaseComponent
 from persica.factory.definition import ObjectDefinition
@@ -37,6 +38,15 @@ class RegisteredOrderedConsumer(BaseComponent):
         self.second = second
 
 
+class RegisteredPhasedDependency(BaseComponent, phase=Phase.REPOSITORY):
+    pass
+
+
+class RegisteredPhasedConsumer(BaseComponent, phase=Phase.SERVICE):
+    def __init__(self, dependency: RegisteredPhasedDependency):
+        self.dependency = dependency
+
+
 class RegisteredFactoryProduct:
     pass
 
@@ -47,6 +57,10 @@ class RegisteredFactoryBase(InterfaceFactory[RegisteredFactoryProduct]):
 
 
 class RegisteredFactoryChild(RegisteredFactoryBase):
+    pass
+
+
+class StalePublishedResource:
     pass
 
 
@@ -113,6 +127,24 @@ def test_registry_registration_supports_ordered_component_instantiation():
     assert isinstance(consumer.second, RegisteredOrderedDependencyTwo)
 
 
+def test_registry_registration_supports_phased_component_instantiation():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=["tests.factory"])
+    scanner.flash()
+    registry = DefinitionRegistry(factory, scanner)
+
+    registry.flash()
+    factory.instantiate_all_objects()
+
+    repository_bucket = factory.order_definitions[Phase.REPOSITORY]
+    service_bucket = factory.order_definitions[Phase.SERVICE]
+    assert {definition.class_object for definition in repository_bucket} == {RegisteredPhasedDependency}
+    assert {definition.class_object for definition in service_bucket} == {RegisteredPhasedConsumer}
+    consumer = factory.singleton_objects.get(RegisteredPhasedConsumer)
+    assert isinstance(consumer, RegisteredPhasedConsumer)
+    assert isinstance(consumer.dependency, RegisteredPhasedDependency)
+
+
 def test_definition_registry_import_state_is_instance_scoped():
     factory = AbstractAutowireCapableFactory()
     scanner = ClassPathScanner(default_base_packages=[])
@@ -154,3 +186,18 @@ def test_registry_flash_replaces_factory_registrations_between_scan_roots():
     assert factory.object_definitions == {RootScannedComponent: factory.object_definitions[RootScannedComponent]}
     assert REGISTERED_ORDER not in factory.order_definitions
     assert {definition.class_object for definition in factory.order_definitions[0]} == {RootScannedComponent}
+
+
+def test_registry_flash_clears_published_resources():
+    factory = AbstractAutowireCapableFactory()
+    scanner = ClassPathScanner(default_base_packages=["tests.sample_registry_root"])
+    scanner.flash()
+    registry = DefinitionRegistry(factory, scanner)
+    stale_resource = StalePublishedResource()
+    factory.published_objects = {StalePublishedResource: [stale_resource]}
+    factory.published_object_sequence = [stale_resource]
+
+    registry.flash()
+
+    assert StalePublishedResource not in factory.published_objects
+    assert factory.published_object_sequence == []

--- a/tests/factory/test_injection_api.py
+++ b/tests/factory/test_injection_api.py
@@ -1,0 +1,690 @@
+import pytest
+
+from persica import inject, inject_all, inject_map
+from persica.error import AmbiguousDependencyException, InvalidInjectionConfigurationError
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.definition import ObjectDefinition
+from persica.factory.interface import InterfaceFactory
+
+
+class PropertyDependency:
+    pass
+
+
+class ExactPropertyDependency(PropertyDependency):
+    pass
+
+
+class AlternatePropertyDependency(PropertyDependency):
+    pass
+
+
+class PropertyTarget:
+    dependency: PropertyDependency = inject()
+
+    def __init__(self):
+        self.observed_dependency = None
+
+    def after_inject(self):
+        self.observed_dependency = self.dependency
+
+
+class BaseInjectedPropertyTarget:
+    dependency: ExactPropertyDependency = inject()
+
+
+class OverrideSuppressesInjectedPropertyTarget(BaseInjectedPropertyTarget):
+    dependency = None
+
+
+class UnresolvedForwardReferenceMixin:
+    pass
+
+
+class NarrowAnnotationPropertyTarget(UnresolvedForwardReferenceMixin):
+    dependency: ExactPropertyDependency = inject()
+
+
+class InheritedMarkerBaseTarget:
+    dependency: PropertyDependency = inject()
+
+
+class InheritedMarkerNarrowTarget(InheritedMarkerBaseTarget):
+    dependency: ExactPropertyDependency
+
+
+class InheritedMarkerExactBaseTarget:
+    dependency: ExactPropertyDependency = inject()
+
+
+class InheritedMarkerWideTarget(InheritedMarkerExactBaseTarget):
+    dependency: PropertyDependency
+
+
+class InheritedMarkerMixin:
+    dependency: ExactPropertyDependency
+
+
+class InheritedMarkerMultipleInheritanceTarget(InheritedMarkerMixin, InheritedMarkerBaseTarget):
+    pass
+
+
+UnresolvedForwardReferenceMixin.__annotations__ = {"broken": "DoesNotExist"}
+
+
+class CollectionDependency:
+    def __init__(self, name: str, key: str | None = None):
+        self.name = name
+        self.key = key
+
+
+class SingletonCollectedDependency(CollectionDependency):
+    pass
+
+
+class ExternalCollectedDependency(CollectionDependency):
+    pass
+
+
+class PublishedCollectedDependency(CollectionDependency):
+    pass
+
+
+class AlternatePublishedCollectedDependency(CollectionDependency):
+    pass
+
+
+class BroadPublishedCollectedDependency(PublishedCollectedDependency):
+    pass
+
+
+class NarrowPublishedCollectedDependency(BroadPublishedCollectedDependency):
+    pass
+
+
+class NarrowCollectionDependency(CollectionDependency):
+    pass
+
+
+class NarrowCollectionDependencyExtra:
+    pass
+
+
+class RegisteredCollectedDependency(CollectionDependency):
+    def __init__(self):
+        super().__init__(name="registered", key="registered")
+
+
+class EarlyOrderedCollectedDependency(CollectionDependency):
+    def __init__(self):
+        super().__init__(name="registered-early", key="registered-early")
+
+
+class LateOrderedCollectedDependency(CollectionDependency):
+    def __init__(self):
+        super().__init__(name="registered-late", key="registered-late")
+
+
+class MissingKeyCollectedDependency(CollectionDependency):
+    pass
+
+
+class OrderedCollectionPublisher:
+    def __init__(self):
+        self.first = PublishedCollectedDependency(name="published-first", key="published-first")
+        self.second = PublishedCollectedDependency(name="published-second", key="published-second")
+
+    def provide_objects(self) -> list[PublishedCollectedDependency]:
+        return [self.first, self.second]
+
+
+class HeterogeneousCollectionPublisher:
+    def __init__(self):
+        self.first = PublishedCollectedDependency(name="published-first", key="published-first")
+        self.second = AlternatePublishedCollectedDependency(name="published-second", key="published-second")
+        self.third = PublishedCollectedDependency(name="published-third", key="published-third")
+
+    def provide_objects(self) -> list[CollectionDependency]:
+        return [self.first, self.second, self.third]
+
+
+class BroadlyAnnotatedSubtypeCollectionPublisher:
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+        self.published = NarrowPublishedCollectedDependency(name="published-narrow", key="published-narrow")
+
+    def provide_objects(self) -> list[CollectionDependency]:
+        return [self.published]
+
+
+class NarrowCollectionConsumer:
+    dependencies: list[NarrowPublishedCollectedDependency] = inject_all()
+
+
+class NarrowKeyedCollectionConsumer:
+    dependencies: dict[str, NarrowPublishedCollectedDependency] = inject_map("key")
+
+
+class BrokenBroadlyAnnotatedSubtypeCollectionPublisher:
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+        self.published = NarrowPublishedCollectedDependency(name="published-narrow", key="published-narrow")
+
+    def provide_objects(self):
+        return [self.published]
+
+
+BrokenBroadlyAnnotatedSubtypeCollectionPublisher.provide_objects.__annotations__ = {
+    "return": "BrokenContainer[BroadPublishedCollectedDependency]"
+}
+
+
+class TooBroadObjectCollectionPublisher:
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+        self.published = object()
+
+    def provide_objects(self) -> list[object]:
+        return [self.published]
+
+
+class NameOverlapCollectionDependency(CollectionDependency):
+    pass
+
+
+class NameOverlapCollectionDependencyExtra(CollectionDependency):
+    pass
+
+
+class BrokenNameOverlapCollectionPublisher:
+    def provide_objects(self):
+        return []
+
+
+BrokenNameOverlapCollectionPublisher.provide_objects.__annotations__ = {
+    "return": "BrokenContainer[NameOverlapCollectionDependencyExtra]"
+}
+
+
+class NameOverlapCollectionConsumer:
+    dependencies: list[NameOverlapCollectionDependency] = inject_all()
+
+
+class OrderedCollectionConsumer:
+    dependencies: list[CollectionDependency] = inject_all()
+
+
+class KeyedCollectionConsumer:
+    dependencies: dict[str, CollectionDependency] = inject_map("key")
+
+
+class DuplicateKeyCollectionPublisher:
+    def __init__(self):
+        self.first = PublishedCollectedDependency(name="published-duplicate", key="duplicate")
+        self.second = PublishedCollectedDependency(name="published-other", key="published-other")
+
+    def provide_objects(self) -> list[PublishedCollectedDependency]:
+        return [self.first, self.second]
+
+
+class MissingKeyCollectionPublisher:
+    def __init__(self):
+        self.published = MissingKeyCollectedDependency(name="missing-key")
+
+    def provide_objects(self) -> list[MissingKeyCollectedDependency]:
+        return [self.published]
+
+
+class NoneKeyCollectionPublisher:
+    def __init__(self):
+        self.published = PublishedCollectedDependency(name="none-key", key=None)
+
+    def provide_objects(self) -> list[PublishedCollectedDependency]:
+        return [self.published]
+
+
+class InvalidAllAnnotationConsumer:
+    dependencies: tuple[CollectionDependency, ...] = inject_all()
+
+
+class InvalidMapAnnotationConsumer:
+    dependencies: list[CollectionDependency] = inject_map("key")
+
+
+class InvalidMapKeyTypeConsumer:
+    dependencies: dict[int, CollectionDependency] = inject_map("key")
+
+
+class FactoryRegisteredCollectionDependency(CollectionDependency):
+    def __init__(self):
+        super().__init__(name="factory-registered", key="factory-registered")
+
+
+class FactoryRuntimeNonCollection:
+    def __init__(self):
+        self.name = "factory-runtime-non-collection"
+        self.key = "factory-runtime-non-collection"
+
+
+class FactoryManagedCollectionDependencyFactory(InterfaceFactory[FactoryRegisteredCollectionDependency]):
+    def get_object(self, obj: FactoryRegisteredCollectionDependency | None) -> FactoryRegisteredCollectionDependency:
+        return FactoryRuntimeNonCollection()  # type: ignore[return-value]
+
+
+def test_property_injection_uses_unique_compatible_external_object():
+    external = ExactPropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.object_definitions = {
+        PropertyTarget: ObjectDefinition(class_object=PropertyTarget),
+    }
+
+    created = factory.create_object(PropertyTarget)
+
+    assert isinstance(created, PropertyTarget)
+    assert created.dependency is external
+
+
+def test_property_injection_raises_for_ambiguous_compatible_resources():
+    factory = AbstractAutowireCapableFactory(
+        external_objects=[ExactPropertyDependency(), AlternatePropertyDependency()]
+    )
+    factory.object_definitions = {
+        PropertyTarget: ObjectDefinition(class_object=PropertyTarget),
+    }
+
+    with pytest.raises(AmbiguousDependencyException) as exc_info:
+        factory.create_object(PropertyTarget)
+
+    assert "dependency" in str(exc_info.value)
+    assert PropertyDependency.__name__ in str(exc_info.value)
+
+
+def test_after_inject_runs_after_property_injection():
+    external = ExactPropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.object_definitions = {
+        PropertyTarget: ObjectDefinition(class_object=PropertyTarget),
+    }
+
+    created = factory.create_object(PropertyTarget)
+
+    assert created.observed_dependency is external
+
+
+def test_subclass_non_marker_override_suppresses_inherited_inject_marker():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        OverrideSuppressesInjectedPropertyTarget: ObjectDefinition(
+            class_object=OverrideSuppressesInjectedPropertyTarget
+        ),
+    }
+
+    created = factory.create_object(OverrideSuppressesInjectedPropertyTarget)
+
+    assert created.dependency is None
+
+
+def test_property_injection_ignores_unrelated_unresolved_forward_reference_annotations():
+    external = ExactPropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.object_definitions = {
+        NarrowAnnotationPropertyTarget: ObjectDefinition(class_object=NarrowAnnotationPropertyTarget),
+    }
+
+    created = factory.create_object(NarrowAnnotationPropertyTarget)
+
+    assert created.dependency is external
+
+
+def test_inherited_inject_marker_uses_subclass_narrowed_annotation():
+    exact = ExactPropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[exact, AlternatePropertyDependency()])
+    factory.object_definitions = {
+        InheritedMarkerNarrowTarget: ObjectDefinition(class_object=InheritedMarkerNarrowTarget),
+    }
+
+    created = factory.create_object(InheritedMarkerNarrowTarget)
+
+    assert created.dependency is exact
+
+
+def test_inherited_inject_marker_uses_subclass_widened_annotation_for_successful_resolution():
+    alternate = AlternatePropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[alternate])
+    factory.object_definitions = {
+        InheritedMarkerWideTarget: ObjectDefinition(class_object=InheritedMarkerWideTarget),
+    }
+
+    created = factory.create_object(InheritedMarkerWideTarget)
+
+    assert created.dependency is alternate
+
+
+def test_inherited_inject_marker_uses_subclass_widened_annotation_for_ambiguity_behavior():
+    factory = AbstractAutowireCapableFactory(
+        external_objects=[ExactPropertyDependency(), AlternatePropertyDependency()]
+    )
+    factory.object_definitions = {
+        InheritedMarkerWideTarget: ObjectDefinition(class_object=InheritedMarkerWideTarget),
+    }
+
+    with pytest.raises(AmbiguousDependencyException) as exc_info:
+        factory.create_object(InheritedMarkerWideTarget)
+
+    assert "dependency" in str(exc_info.value)
+    assert PropertyDependency.__name__ in str(exc_info.value)
+
+
+def test_inherited_inject_marker_uses_earlier_mixin_annotation_override_in_final_mro():
+    exact = ExactPropertyDependency()
+    factory = AbstractAutowireCapableFactory(external_objects=[exact, AlternatePropertyDependency()])
+    factory.object_definitions = {
+        InheritedMarkerMultipleInheritanceTarget: ObjectDefinition(
+            class_object=InheritedMarkerMultipleInheritanceTarget
+        ),
+    }
+
+    created = factory.create_object(InheritedMarkerMultipleInheritanceTarget)
+
+    assert created.dependency is exact
+
+
+def test_inject_all_collects_compatible_objects_in_stable_source_order():
+    singleton = SingletonCollectedDependency(name="singleton", key="singleton")
+    external = ExternalCollectedDependency(name="external", key="external")
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.singleton_objects[SingletonCollectedDependency] = singleton
+    factory.object_definitions = {
+        OrderedCollectionConsumer: ObjectDefinition(class_object=OrderedCollectionConsumer),
+        OrderedCollectionPublisher: ObjectDefinition(class_object=OrderedCollectionPublisher),
+        RegisteredCollectedDependency: ObjectDefinition(class_object=RegisteredCollectedDependency),
+    }
+
+    created = factory.create_object(OrderedCollectionConsumer)
+
+    assert [dependency.name for dependency in created.dependencies] == [
+        "singleton",
+        "external",
+        "published-first",
+        "published-second",
+        "registered",
+    ]
+
+
+def test_inject_map_builds_keyed_collection_from_all_compatible_sources():
+    singleton = SingletonCollectedDependency(name="singleton", key="singleton")
+    external = ExternalCollectedDependency(name="external", key="external")
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.singleton_objects[SingletonCollectedDependency] = singleton
+    factory.object_definitions = {
+        KeyedCollectionConsumer: ObjectDefinition(class_object=KeyedCollectionConsumer),
+        OrderedCollectionPublisher: ObjectDefinition(class_object=OrderedCollectionPublisher),
+        RegisteredCollectedDependency: ObjectDefinition(class_object=RegisteredCollectedDependency),
+    }
+
+    created = factory.create_object(KeyedCollectionConsumer)
+
+    assert list(created.dependencies) == [
+        "singleton",
+        "external",
+        "published-first",
+        "published-second",
+        "registered",
+    ]
+    assert [dependency.name for dependency in created.dependencies.values()] == [
+        "singleton",
+        "external",
+        "published-first",
+        "published-second",
+        "registered",
+    ]
+
+
+def test_inject_map_raises_for_duplicate_keys():
+    external = ExternalCollectedDependency(name="external-duplicate", key="duplicate")
+    factory = AbstractAutowireCapableFactory(external_objects=[external])
+    factory.object_definitions = {
+        KeyedCollectionConsumer: ObjectDefinition(class_object=KeyedCollectionConsumer),
+        DuplicateKeyCollectionPublisher: ObjectDefinition(class_object=DuplicateKeyCollectionPublisher),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(KeyedCollectionConsumer)
+
+    assert "duplicate" in str(exc_info.value)
+    assert "key" in str(exc_info.value)
+
+
+def test_inject_map_raises_when_key_attribute_is_missing():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        KeyedCollectionConsumer: ObjectDefinition(class_object=KeyedCollectionConsumer),
+        MissingKeyCollectionPublisher: ObjectDefinition(class_object=MissingKeyCollectionPublisher),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(KeyedCollectionConsumer)
+
+    assert "key" in str(exc_info.value)
+    assert "MissingKeyCollectedDependency" in str(exc_info.value)
+
+
+def test_inject_map_raises_when_key_value_is_none():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        KeyedCollectionConsumer: ObjectDefinition(class_object=KeyedCollectionConsumer),
+        NoneKeyCollectionPublisher: ObjectDefinition(class_object=NoneKeyCollectionPublisher),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(KeyedCollectionConsumer)
+
+    assert "None" in str(exc_info.value)
+    assert "key" in str(exc_info.value)
+
+
+def test_inject_all_rejects_invalid_annotation_shape():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        InvalidAllAnnotationConsumer: ObjectDefinition(class_object=InvalidAllAnnotationConsumer),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(InvalidAllAnnotationConsumer)
+
+    assert "list" in str(exc_info.value)
+
+
+def test_inject_map_rejects_invalid_annotation_shape():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        InvalidMapAnnotationConsumer: ObjectDefinition(class_object=InvalidMapAnnotationConsumer),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(InvalidMapAnnotationConsumer)
+
+    assert "dict" in str(exc_info.value)
+
+
+def test_inject_all_preserves_actual_publication_order_across_mixed_types():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        OrderedCollectionConsumer: ObjectDefinition(class_object=OrderedCollectionConsumer),
+        HeterogeneousCollectionPublisher: ObjectDefinition(class_object=HeterogeneousCollectionPublisher),
+    }
+
+    created = factory.create_object(OrderedCollectionConsumer)
+
+    assert [dependency.name for dependency in created.dependencies] == [
+        "published-first",
+        "published-second",
+        "published-third",
+    ]
+
+
+def test_inject_all_uses_order_buckets_for_registered_definitions():
+    factory = AbstractAutowireCapableFactory()
+    early_definition = ObjectDefinition(class_object=EarlyOrderedCollectedDependency)
+    late_definition = ObjectDefinition(class_object=LateOrderedCollectedDependency)
+    consumer_definition = ObjectDefinition(class_object=OrderedCollectionConsumer)
+    factory.order_definitions = {
+        20: [late_definition],
+        10: [early_definition],
+    }
+    factory.object_definitions = {
+        OrderedCollectionConsumer: consumer_definition,
+        LateOrderedCollectedDependency: late_definition,
+        EarlyOrderedCollectedDependency: early_definition,
+    }
+
+    created = factory.create_object(OrderedCollectionConsumer)
+
+    assert [dependency.name for dependency in created.dependencies] == [
+        "registered-early",
+        "registered-late",
+    ]
+
+
+def test_inject_map_validates_runtime_key_type_from_annotation():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        InvalidMapKeyTypeConsumer: ObjectDefinition(class_object=InvalidMapKeyTypeConsumer),
+        OrderedCollectionPublisher: ObjectDefinition(class_object=OrderedCollectionPublisher),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(InvalidMapKeyTypeConsumer)
+
+    assert "int" in str(exc_info.value)
+    assert "str" in str(exc_info.value)
+
+
+def test_inject_all_does_not_discover_subtypes_from_broad_return_annotations_on_demand():
+    factory = AbstractAutowireCapableFactory()
+    BroadlyAnnotatedSubtypeCollectionPublisher.instantiated = False
+    factory.object_definitions = {
+        NarrowCollectionConsumer: ObjectDefinition(class_object=NarrowCollectionConsumer),
+        BroadlyAnnotatedSubtypeCollectionPublisher: ObjectDefinition(
+            class_object=BroadlyAnnotatedSubtypeCollectionPublisher
+        ),
+    }
+
+    created = factory.create_object(NarrowCollectionConsumer)
+
+    assert created.dependencies == []
+    assert BroadlyAnnotatedSubtypeCollectionPublisher.instantiated is False
+
+
+def test_inject_map_does_not_discover_subtypes_from_broad_return_annotations_on_demand():
+    factory = AbstractAutowireCapableFactory()
+    BroadlyAnnotatedSubtypeCollectionPublisher.instantiated = False
+    factory.object_definitions = {
+        NarrowKeyedCollectionConsumer: ObjectDefinition(class_object=NarrowKeyedCollectionConsumer),
+        BroadlyAnnotatedSubtypeCollectionPublisher: ObjectDefinition(
+            class_object=BroadlyAnnotatedSubtypeCollectionPublisher
+        ),
+    }
+
+    created = factory.create_object(NarrowKeyedCollectionConsumer)
+
+    assert created.dependencies == {}
+    assert BroadlyAnnotatedSubtypeCollectionPublisher.instantiated is False
+
+
+def test_inject_all_ignores_broken_broad_publisher_annotation_when_consumer_requests_subtype():
+    factory = AbstractAutowireCapableFactory()
+    BrokenBroadlyAnnotatedSubtypeCollectionPublisher.instantiated = False
+    factory.object_definitions = {
+        NarrowCollectionConsumer: ObjectDefinition(class_object=NarrowCollectionConsumer),
+        BrokenBroadlyAnnotatedSubtypeCollectionPublisher: ObjectDefinition(
+            class_object=BrokenBroadlyAnnotatedSubtypeCollectionPublisher
+        ),
+    }
+
+    created = factory.create_object(NarrowCollectionConsumer)
+
+    assert created.dependencies == []
+    assert BrokenBroadlyAnnotatedSubtypeCollectionPublisher.instantiated is False
+
+
+def test_inject_map_ignores_broken_broad_publisher_annotation_when_consumer_requests_subtype():
+    factory = AbstractAutowireCapableFactory()
+    BrokenBroadlyAnnotatedSubtypeCollectionPublisher.instantiated = False
+    factory.object_definitions = {
+        NarrowKeyedCollectionConsumer: ObjectDefinition(class_object=NarrowKeyedCollectionConsumer),
+        BrokenBroadlyAnnotatedSubtypeCollectionPublisher: ObjectDefinition(
+            class_object=BrokenBroadlyAnnotatedSubtypeCollectionPublisher
+        ),
+    }
+
+    created = factory.create_object(NarrowKeyedCollectionConsumer)
+
+    assert created.dependencies == {}
+    assert BrokenBroadlyAnnotatedSubtypeCollectionPublisher.instantiated is False
+
+
+def test_inject_all_does_not_instantiate_object_annotated_publishers_for_unrelated_subtype_requests():
+    factory = AbstractAutowireCapableFactory()
+    TooBroadObjectCollectionPublisher.instantiated = False
+    factory.object_definitions = {
+        NarrowCollectionConsumer: ObjectDefinition(class_object=NarrowCollectionConsumer),
+        TooBroadObjectCollectionPublisher: ObjectDefinition(class_object=TooBroadObjectCollectionPublisher),
+    }
+
+    created = factory.create_object(NarrowCollectionConsumer)
+
+    assert created.dependencies == []
+    assert TooBroadObjectCollectionPublisher.instantiated is False
+
+
+def test_inject_all_ignores_unresolved_annotation_name_overlap_false_positive():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        NameOverlapCollectionConsumer: ObjectDefinition(class_object=NameOverlapCollectionConsumer),
+        BrokenNameOverlapCollectionPublisher: ObjectDefinition(class_object=BrokenNameOverlapCollectionPublisher),
+    }
+
+    created = factory.create_object(NameOverlapCollectionConsumer)
+
+    assert created.dependencies == []
+
+
+def test_inject_all_filters_factory_managed_instances_by_runtime_type():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        OrderedCollectionConsumer: ObjectDefinition(class_object=OrderedCollectionConsumer),
+        FactoryRegisteredCollectionDependency: ObjectDefinition(class_object=FactoryRegisteredCollectionDependency),
+        FactoryManagedCollectionDependencyFactory: ObjectDefinition(
+            class_object=FactoryManagedCollectionDependencyFactory,
+            is_factory=True,
+        ),
+    }
+
+    created = factory.create_object(OrderedCollectionConsumer)
+
+    assert created.dependencies == []
+    assert isinstance(factory.singleton_objects[FactoryRegisteredCollectionDependency], FactoryRuntimeNonCollection)
+
+
+def test_inject_map_filters_factory_managed_instances_by_runtime_type():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        KeyedCollectionConsumer: ObjectDefinition(class_object=KeyedCollectionConsumer),
+        FactoryRegisteredCollectionDependency: ObjectDefinition(class_object=FactoryRegisteredCollectionDependency),
+        FactoryManagedCollectionDependencyFactory: ObjectDefinition(
+            class_object=FactoryManagedCollectionDependencyFactory,
+            is_factory=True,
+        ),
+    }
+
+    created = factory.create_object(KeyedCollectionConsumer)
+
+    assert created.dependencies == {}
+    assert isinstance(factory.singleton_objects[FactoryRegisteredCollectionDependency], FactoryRuntimeNonCollection)

--- a/tests/factory/test_phase.py
+++ b/tests/factory/test_phase.py
@@ -1,0 +1,69 @@
+import pytest
+
+from persica import Phase, inject, inject_all, inject_map
+from persica import Phase as PublicPhase
+from persica import inject as public_inject
+from persica import inject_all as public_inject_all
+from persica import inject_map as public_inject_map
+from persica.factory.component import BaseComponent
+
+EXPECTED_PHASE_VALUES = {
+    Phase.DEPENDENCY: 10,
+    Phase.REPOSITORY: 20,
+    Phase.SERVICE: 30,
+    Phase.COMMAND: 40,
+    Phase.JOB: 50,
+}
+
+
+def test_injection_helpers_return_distinct_marker_configurations():
+    single = inject()
+    all_values = inject_all()
+    mapped = inject_map("name")
+
+    assert single.kind == "single"
+    assert single.key_attr is None
+    assert all_values.kind == "all"
+    assert all_values.key_attr is None
+    assert mapped.kind == "map"
+    assert mapped.key_attr == "name"
+
+
+def test_public_api_exports_are_importable_from_persica():
+    assert PublicPhase is Phase
+    assert public_inject is inject
+    assert public_inject_all is inject_all
+    assert public_inject_map is inject_map
+
+
+def test_phase_values_are_stable_and_ordered():
+    for phase, expected_value in EXPECTED_PHASE_VALUES.items():
+        assert phase == expected_value
+    assert list(Phase) == [
+        Phase.DEPENDENCY,
+        Phase.REPOSITORY,
+        Phase.SERVICE,
+        Phase.COMMAND,
+        Phase.JOB,
+    ]
+
+
+def test_component_phase_keyword_sets_order_attribute():
+    class PhasedComponent(BaseComponent, phase=Phase.JOB):
+        pass
+
+    assert PhasedComponent.__order__ == Phase.JOB
+
+
+def test_component_phase_and_order_keywords_conflict():
+    with pytest.raises(TypeError, match="phase.*order"):
+
+        class InvalidComponent(BaseComponent, phase=Phase.SERVICE, order=1):
+            pass
+
+
+def test_component_phase_keyword_requires_phase_enum_value():
+    with pytest.raises(TypeError, match="Phase"):
+
+        class InvalidPhaseComponent(BaseComponent, phase="service"):
+            pass

--- a/tests/factory/test_resource_publishing.py
+++ b/tests/factory/test_resource_publishing.py
@@ -1,0 +1,608 @@
+import pytest
+
+from persica import inject
+from persica.error import AmbiguousDependencyException, InvalidInjectionConfigurationError, NoSuchParameterException
+from persica.factory.abstract import AbstractAutowireCapableFactory
+from persica.factory.definition import ObjectDefinition
+from persica.factory.interface import InterfaceFactory
+
+
+class PublishedBaseResource:
+    pass
+
+
+class PublishedResource(PublishedBaseResource):
+    pass
+
+
+class RegisteredPublishedResource(PublishedResource):
+    pass
+
+
+class DefinedPublishedResource:
+    pass
+
+
+class CompatibleRegisteredResource(PublishedBaseResource):
+    pass
+
+
+class ResourcePublishingComponent:
+    def __init__(self):
+        self.published = PublishedResource()
+        self.after_inject_dependency = None
+
+    def provide_objects(self) -> list[PublishedResource]:
+        return [self.published]
+
+    def after_inject(self):
+        self.after_inject_dependency = self.published
+
+
+class BroadlyAnnotatedPublishingComponent:
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+        self.published = PublishedResource()
+
+    def provide_objects(self) -> list[PublishedBaseResource]:
+        return [self.published]
+
+
+class TooBroadObjectPublishingComponent:
+    instantiated = False
+
+    def __init__(self):
+        type(self).instantiated = True
+        self.published = object()
+
+    def provide_objects(self) -> list[object]:
+        return [self.published]
+
+
+class FactoryManagedDependency:
+    pass
+
+
+class FactoryManagedPublishedResource:
+    pass
+
+
+class ReplacementPublishedProduct:
+    pass
+
+
+class FactoryManagedPublishedComponent:
+    dependency: FactoryManagedDependency = inject()
+
+    def __init__(self):
+        self.published = FactoryManagedPublishedResource()
+        self.after_inject_dependency = None
+
+    def provide_objects(self) -> list[FactoryManagedPublishedResource]:
+        return [self.published]
+
+    def after_inject(self):
+        self.after_inject_dependency = self.dependency
+
+
+class FactoryManagedPublishedComponentFactory(InterfaceFactory[FactoryManagedPublishedComponent]):
+    source: FactoryManagedPublishedComponent | None = None
+
+    @classmethod
+    def get_class(cls):
+        return FactoryManagedPublishedComponent
+
+    def get_object(
+        self, obj: FactoryManagedPublishedComponent | None
+    ) -> FactoryManagedPublishedComponent | ReplacementPublishedProduct:
+        type(self).source = obj
+        return ReplacementPublishedProduct()
+
+
+class FactoryManagedPublishedResourceConsumer:
+    resource: FactoryManagedPublishedResource = inject()
+
+
+class PublishedResourceConsumer:
+    resource: PublishedResource = inject()
+    compatible_resource: PublishedBaseResource = inject()
+
+
+class ExactTypePublishingComponent:
+    def __init__(self):
+        self.published = DefinedPublishedResource()
+
+    def provide_objects(self) -> list[DefinedPublishedResource]:
+        return [self.published]
+
+
+class DuplicatePublishingComponent:
+    def __init__(self):
+        self.first = PublishedResource()
+        self.second = PublishedResource()
+
+    def provide_objects(self) -> list[PublishedResource]:
+        return [self.first, self.second]
+
+
+class TuplePublishingComponent:
+    def __init__(self):
+        self.published = PublishedResource()
+
+    def provide_objects(self) -> list[PublishedResource]:
+        return (self.published,)
+
+
+class UnresolvedAnnotatedPublisher:
+    def __init__(self):
+        self.published = PublishedResource()
+
+    def provide_objects(self):
+        return [self.published]
+
+
+UnresolvedAnnotatedPublisher.provide_objects.__annotations__ = {"return": "DoesNotExist"}
+
+
+class RelevantBrokenPublishedResourcePublisher:
+    def __init__(self):
+        self.published = PublishedResource()
+
+    def provide_objects(self):
+        return [self.published]
+
+
+RelevantBrokenPublishedResourcePublisher.provide_objects.__annotations__ = {
+    "return": "BrokenContainer[PublishedResource]"
+}
+
+
+class RelevantBrokenBroadPublishedResourcePublisher:
+    def __init__(self):
+        self.published = PublishedResource()
+
+    def provide_objects(self):
+        return [self.published]
+
+
+RelevantBrokenBroadPublishedResourcePublisher.provide_objects.__annotations__ = {
+    "return": "BrokenContainer[PublishedBaseResource]"
+}
+
+
+class CollisionNamespaceA:
+    class SharedPublishedResource:
+        pass
+
+
+class CollisionNamespaceB:
+    class SharedPublishedResource:
+        pass
+
+
+class CollisionExactPublishedResourceConsumer:
+    resource: CollisionNamespaceA.SharedPublishedResource = inject()
+
+
+class CollisionExactPublishingComponent:
+    def __init__(self):
+        self.published = CollisionNamespaceA.SharedPublishedResource()
+
+    def provide_objects(self) -> list[CollisionNamespaceA.SharedPublishedResource]:
+        return [self.published]
+
+
+class CollisionBrokenPublishedResourcePublisher:
+    def provide_objects(self):
+        return []
+
+
+CollisionBrokenPublishedResourcePublisher.provide_objects.__annotations__ = {
+    "return": "BrokenContainer[SharedPublishedResource]"
+}
+
+
+class AfterInjectFailurePublishedResource:
+    pass
+
+
+class FailingAfterInjectPublisher:
+    def __init__(self):
+        self.published = AfterInjectFailurePublishedResource()
+
+    def provide_objects(self) -> list[AfterInjectFailurePublishedResource]:
+        return [self.published]
+
+    def after_inject(self):
+        raise RuntimeError("after_inject failed")
+
+
+class AfterInjectFailureConsumer:
+    resource: AfterInjectFailurePublishedResource = inject()
+
+
+class ClassLocalTypePublishingComponent:
+    class LocalPublishedResource:
+        pass
+
+    def __init__(self):
+        self.published = self.LocalPublishedResource()
+
+    def provide_objects(self):
+        return [self.published]
+
+
+ClassLocalTypePublishingComponent.provide_objects.__annotations__ = {"return": "list[LocalPublishedResource]"}
+
+
+class ClassLocalTypePublishedResourceConsumer:
+    resource: ClassLocalTypePublishingComponent.LocalPublishedResource = inject()
+
+
+class CompatiblePublishedResourceOnlyConsumer:
+    compatible_resource: PublishedBaseResource = inject()
+
+
+class ConstructorPublishedResourceConsumer:
+    def __init__(self, resource: PublishedResource, compatible_resource: PublishedBaseResource):
+        self.resource = resource
+        self.compatible_resource = compatible_resource
+
+
+class ExactPublishedResourcePropertyConsumer:
+    resource: DefinedPublishedResource = inject()
+
+
+class ExactPublishedResourceOnlyConsumer:
+    resource: PublishedResource = inject()
+
+
+class ExactPublishedResourceConstructorConsumer:
+    def __init__(self, resource: DefinedPublishedResource):
+        self.resource = resource
+
+
+class BrokenDependency:
+    pass
+
+
+class UnrelatedBrokenComponent:
+    def __init__(self, dependency: BrokenDependency):
+        self.dependency = dependency
+
+
+def test_published_resources_are_injectable_for_exact_and_compatible_property_injection():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+    }
+
+    factory.instantiate_all_objects()
+
+    publisher = factory.singleton_objects[ResourcePublishingComponent]
+    consumer = factory.singleton_objects[PublishedResourceConsumer]
+    assert consumer.resource is publisher.published
+    assert consumer.compatible_resource is publisher.published
+
+
+def test_published_resources_are_injectable_when_publisher_is_registered_after_consumer():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    factory.instantiate_all_objects()
+
+    publisher = factory.singleton_objects[ResourcePublishingComponent]
+    consumer = factory.singleton_objects[PublishedResourceConsumer]
+    assert consumer.resource is publisher.published
+    assert consumer.compatible_resource is publisher.published
+
+
+def test_exact_published_resource_discovery_ignores_broader_declared_return_types():
+    factory = AbstractAutowireCapableFactory()
+    BroadlyAnnotatedPublishingComponent.instantiated = False
+    factory.object_definitions = {
+        ExactPublishedResourceOnlyConsumer: ObjectDefinition(class_object=ExactPublishedResourceOnlyConsumer),
+        BroadlyAnnotatedPublishingComponent: ObjectDefinition(class_object=BroadlyAnnotatedPublishingComponent),
+    }
+
+    with pytest.raises(NoSuchParameterException) as exc_info:
+        factory.create_object(ExactPublishedResourceOnlyConsumer)
+
+    assert BroadlyAnnotatedPublishingComponent.instantiated is False
+    assert "PublishedResource" in str(exc_info.value)
+
+
+def test_exact_published_resource_discovery_ignores_object_annotated_publishers_for_concrete_requests():
+    factory = AbstractAutowireCapableFactory()
+    TooBroadObjectPublishingComponent.instantiated = False
+    factory.object_definitions = {
+        ExactPublishedResourceOnlyConsumer: ObjectDefinition(class_object=ExactPublishedResourceOnlyConsumer),
+        TooBroadObjectPublishingComponent: ObjectDefinition(class_object=TooBroadObjectPublishingComponent),
+    }
+
+    with pytest.raises(NoSuchParameterException) as exc_info:
+        factory.create_object(ExactPublishedResourceOnlyConsumer)
+
+    assert TooBroadObjectPublishingComponent.instantiated is False
+    assert "PublishedResource" in str(exc_info.value)
+
+
+def test_property_injection_only_instantiates_matching_publishers_for_missing_resources():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+        UnrelatedBrokenComponent: ObjectDefinition(class_object=UnrelatedBrokenComponent),
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    created = factory.create_object(PublishedResourceConsumer)
+
+    publisher = factory.singleton_objects[ResourcePublishingComponent]
+    assert created.resource is publisher.published
+    assert created.compatible_resource is publisher.published
+    assert UnrelatedBrokenComponent not in factory.singleton_objects
+
+
+def test_constructor_injection_uses_published_resources_when_publisher_is_registered_after_consumer():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ConstructorPublishedResourceConsumer: ObjectDefinition(class_object=ConstructorPublishedResourceConsumer),
+        UnrelatedBrokenComponent: ObjectDefinition(class_object=UnrelatedBrokenComponent),
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    created = factory.create_object(ConstructorPublishedResourceConsumer)
+
+    publisher = factory.singleton_objects[ResourcePublishingComponent]
+    assert created.resource is publisher.published
+    assert created.compatible_resource is publisher.published
+    assert UnrelatedBrokenComponent not in factory.singleton_objects
+
+
+def test_exact_registered_definition_beats_published_resource_for_property_injection():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactPublishedResourcePropertyConsumer: ObjectDefinition(class_object=ExactPublishedResourcePropertyConsumer),
+        DefinedPublishedResource: ObjectDefinition(class_object=DefinedPublishedResource),
+        ExactTypePublishingComponent: ObjectDefinition(class_object=ExactTypePublishingComponent),
+    }
+
+    created = factory.create_object(ExactPublishedResourcePropertyConsumer)
+
+    assert isinstance(created.resource, DefinedPublishedResource)
+    assert created.resource is factory.singleton_objects[DefinedPublishedResource]
+
+
+def test_exact_registered_definition_beats_published_resource_for_constructor_injection():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactPublishedResourceConstructorConsumer: ObjectDefinition(
+            class_object=ExactPublishedResourceConstructorConsumer
+        ),
+        DefinedPublishedResource: ObjectDefinition(class_object=DefinedPublishedResource),
+        ExactTypePublishingComponent: ObjectDefinition(class_object=ExactTypePublishingComponent),
+    }
+
+    created = factory.create_object(ExactPublishedResourceConstructorConsumer)
+
+    assert isinstance(created.resource, DefinedPublishedResource)
+    assert created.resource is factory.singleton_objects[DefinedPublishedResource]
+
+
+def test_compatible_registered_definition_beats_compatible_published_resource():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+        CompatibleRegisteredResource: ObjectDefinition(class_object=CompatibleRegisteredResource),
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    created = factory.create_object(PublishedResourceConsumer)
+
+    assert isinstance(created.compatible_resource, CompatibleRegisteredResource)
+    assert created.compatible_resource is factory.singleton_objects[CompatibleRegisteredResource]
+
+
+def test_compatible_registered_definition_beats_already_published_compatible_resource():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+        CompatibleRegisteredResource: ObjectDefinition(class_object=CompatibleRegisteredResource),
+    }
+
+    factory.create_object(ResourcePublishingComponent)
+    created = factory.create_object(PublishedResourceConsumer)
+
+    assert isinstance(created.compatible_resource, CompatibleRegisteredResource)
+    assert created.compatible_resource is factory.singleton_objects[CompatibleRegisteredResource]
+
+
+def test_after_inject_runs_after_resource_publication():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    created = factory.create_object(ResourcePublishingComponent)
+
+    assert created.after_inject_dependency is created.published
+
+
+def test_published_resources_roll_back_when_after_inject_fails():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        FailingAfterInjectPublisher: ObjectDefinition(class_object=FailingAfterInjectPublisher),
+        AfterInjectFailureConsumer: ObjectDefinition(class_object=AfterInjectFailureConsumer),
+    }
+
+    with pytest.raises(RuntimeError) as exc_info:
+        factory.create_object(FailingAfterInjectPublisher)
+
+    assert "after_inject failed" in str(exc_info.value)
+    assert AfterInjectFailurePublishedResource not in factory.published_objects
+    assert factory.published_object_sequence == []
+
+    with pytest.raises(RuntimeError) as retry_exc_info:
+        factory.create_object(AfterInjectFailureConsumer)
+
+    assert "after_inject failed" in str(retry_exc_info.value)
+    assert AfterInjectFailurePublishedResource not in factory.published_objects
+    assert factory.published_object_sequence == []
+
+
+def test_publisher_discovery_resolves_class_local_return_annotation_names():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ClassLocalTypePublishedResourceConsumer: ObjectDefinition(class_object=ClassLocalTypePublishedResourceConsumer),
+        ClassLocalTypePublishingComponent: ObjectDefinition(class_object=ClassLocalTypePublishingComponent),
+    }
+
+    created = factory.create_object(ClassLocalTypePublishedResourceConsumer)
+
+    publisher = factory.singleton_objects[ClassLocalTypePublishingComponent]
+    assert created.resource is publisher.published
+
+
+def test_factory_replacement_preserves_task2_wiring_on_registered_component_instance():
+    factory = AbstractAutowireCapableFactory(external_objects=[FactoryManagedDependency()])
+    FactoryManagedPublishedComponentFactory.source = None
+    factory.object_definitions = {
+        FactoryManagedPublishedComponentFactory: ObjectDefinition(
+            class_object=FactoryManagedPublishedComponentFactory,
+            is_factory=True,
+        ),
+        FactoryManagedPublishedComponent: ObjectDefinition(class_object=FactoryManagedPublishedComponent),
+        FactoryManagedPublishedResourceConsumer: ObjectDefinition(class_object=FactoryManagedPublishedResourceConsumer),
+    }
+
+    created = factory.create_object(FactoryManagedPublishedComponent)
+    source = FactoryManagedPublishedComponentFactory.source
+
+    assert isinstance(created, ReplacementPublishedProduct)
+    assert factory.singleton_objects[FactoryManagedPublishedComponent] is created
+    assert source is not None
+    assert isinstance(source.dependency, FactoryManagedDependency)
+    assert source.after_inject_dependency is source.dependency
+
+    consumer = factory.create_object(FactoryManagedPublishedResourceConsumer)
+    assert consumer.resource is source.published
+
+
+def test_published_resources_are_not_registered_as_lifecycle_components():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+    }
+
+    factory.instantiate_all_objects()
+
+    assert PublishedResource not in factory.object_definitions
+    assert PublishedResource not in factory.singleton_objects
+
+
+def test_duplicate_published_resources_of_same_runtime_type_raise_ambiguity():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        DuplicatePublishingComponent: ObjectDefinition(class_object=DuplicatePublishingComponent),
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+    }
+
+    with pytest.raises(AmbiguousDependencyException) as exc_info:
+        factory.instantiate_all_objects()
+
+    assert PublishedResource.__name__ in str(exc_info.value)
+
+
+def test_provide_objects_requires_list_return_value():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        TuplePublishingComponent: ObjectDefinition(class_object=TuplePublishingComponent),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(TuplePublishingComponent)
+
+    assert "must return a list" in str(exc_info.value)
+
+
+def test_publisher_discovery_ignores_unrelated_unresolved_return_annotation():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        PublishedResourceConsumer: ObjectDefinition(class_object=PublishedResourceConsumer),
+        UnresolvedAnnotatedPublisher: ObjectDefinition(class_object=UnresolvedAnnotatedPublisher),
+        ResourcePublishingComponent: ObjectDefinition(class_object=ResourcePublishingComponent),
+    }
+
+    created = factory.create_object(PublishedResourceConsumer)
+
+    publisher = factory.singleton_objects[ResourcePublishingComponent]
+    assert created.resource is publisher.published
+
+
+def test_relevant_broken_publisher_annotation_raises_configuration_error():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactPublishedResourceOnlyConsumer: ObjectDefinition(class_object=ExactPublishedResourceOnlyConsumer),
+        RelevantBrokenPublishedResourcePublisher: ObjectDefinition(
+            class_object=RelevantBrokenPublishedResourcePublisher
+        ),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(ExactPublishedResourceOnlyConsumer)
+
+    assert "RelevantBrokenPublishedResourcePublisher.provide_objects() return annotation" in str(exc_info.value)
+
+
+def test_exact_published_resource_discovery_ignores_broken_broader_return_annotations():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        ExactPublishedResourceOnlyConsumer: ObjectDefinition(class_object=ExactPublishedResourceOnlyConsumer),
+        RelevantBrokenBroadPublishedResourcePublisher: ObjectDefinition(
+            class_object=RelevantBrokenBroadPublishedResourcePublisher
+        ),
+    }
+
+    with pytest.raises(NoSuchParameterException) as exc_info:
+        factory.create_object(ExactPublishedResourceOnlyConsumer)
+
+    assert "PublishedResource" in str(exc_info.value)
+
+
+def test_compatible_relevant_broken_publisher_annotation_raises_configuration_error():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        CompatiblePublishedResourceOnlyConsumer: ObjectDefinition(class_object=CompatiblePublishedResourceOnlyConsumer),
+        RelevantBrokenPublishedResourcePublisher: ObjectDefinition(
+            class_object=RelevantBrokenPublishedResourcePublisher
+        ),
+    }
+
+    with pytest.raises(InvalidInjectionConfigurationError) as exc_info:
+        factory.create_object(CompatiblePublishedResourceOnlyConsumer)
+
+    assert "RelevantBrokenPublishedResourcePublisher.provide_objects() return annotation" in str(exc_info.value)
+
+
+def test_exact_published_resource_discovery_ignores_ambiguous_simple_name_broken_annotations():
+    factory = AbstractAutowireCapableFactory()
+    factory.object_definitions = {
+        CollisionExactPublishedResourceConsumer: ObjectDefinition(class_object=CollisionExactPublishedResourceConsumer),
+        CollisionBrokenPublishedResourcePublisher: ObjectDefinition(
+            class_object=CollisionBrokenPublishedResourcePublisher
+        ),
+        CollisionExactPublishingComponent: ObjectDefinition(class_object=CollisionExactPublishingComponent),
+    }
+
+    created = factory.create_object(CollisionExactPublishedResourceConsumer)
+
+    publisher = factory.singleton_objects[CollisionExactPublishingComponent]
+    assert created.resource is publisher.published

--- a/tests/repeated_run_publish_package/components.py
+++ b/tests/repeated_run_publish_package/components.py
@@ -1,0 +1,7 @@
+from persica import inject
+from persica.factory.component import BaseComponent
+from tests.repeated_run_publish_package.shared import RepeatedRunPublishedResource
+
+
+class RepeatedRunPublishedResourceConsumer(BaseComponent):
+    resource: RepeatedRunPublishedResource = inject()

--- a/tests/repeated_run_publish_package/shared.py
+++ b/tests/repeated_run_publish_package/shared.py
@@ -1,0 +1,3 @@
+class RepeatedRunPublishedResource:
+    def __init__(self, value: str):
+        self.value = value


### PR DESCRIPTION
## Summary
- add `Phase`, `inject()`, `inject_all()`, and `inject_map()` so Persica components can declare dependencies without most custom wiring factories
- support published runtime resources and `after_inject()` hooks, including app-level resource publication through `Application.provide_objects()`
- add regression coverage for ordering, resource publication, repeated startup resets, inheritance edge cases, and factory replacement behavior

## Test Plan
- [x] `uv run ruff check`
- [x] `uv run pytest`
- [x] `uv build`